### PR TITLE
docs: fix broken demo install command + sharpen hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@
 
 <h1>Agentmetry: the local flight recorder for AI coding agents</h1>
 
-<p>Records every tool call, denial, and human approval from Cursor, Claude Code, Codex and Antigravity.<br/>
-Tags each one with MITRE ATT&CK, correlates sequences into detections, and stores it all in a JSONL trail you own.<br/>
+<p><strong>Your agent reads a private key, then makes a network call. Your EDR sees a process.<br/>
+Agentmetry sees the sequence, tags it with MITRE ATT&CK, and fires one CRITICAL alert.</strong></p>
+
+<p>Records every tool call, denial, and approval from Cursor, Claude Code, Codex and Antigravity into a JSONL trail you own.<br/>
 Runs on your machine. Forward to Loki, Elastic, or Splunk only if you want to.</p>
 
 <p align="center">
@@ -92,7 +94,7 @@ No server, no API key, no config. Clone and run:
 
 ```bash
 git clone https://github.com/blitzcrieg1/agentmetry.git && cd agentmetry
-pip install -r apps/orchestrator/requirements.txt
+pip install -e apps/orchestrator
 python scripts/demo.py
 ```
 

--- a/apps/orchestrator/tests/test_audit_stats.py
+++ b/apps/orchestrator/tests/test_audit_stats.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 


### PR DESCRIPTION
## The bug

The 30-second demo — the README's flagship hook **and** the [agentmetry.ai](https://agentmetry.ai) primary CTA — told readers to:

```
pip install -r apps/orchestrator/requirements.txt
```

That file **does not exist**. The command fails on line 2 of a clean clone, before the demo ever runs. `demo.py` imports the orchestrator (needs `pydantic`/`httpx`, not stdlib-only), so the install is required, not optional.

Fixed to point at the real package:

```
pip install -e apps/orchestrator
```

Verified: the demo runs end-to-end and its output matches the README's claims; `pip install -e apps/orchestrator` resolves cleanly (`agentmetry-orchestrator`).

## Also

Led the hero with the concrete attack story (key read → network call → one CRITICAL alert) so the README hero matches the site hero and a 5-second skim lands the value before the feature list. The informative line (IDEs, JSONL trail, SIEM forwarding) is preserved below it.

## Note

The `requirements.txt` reference has been broken on `master`, so this affects anyone cloning today. The companion fix to the site CTA (`ai-audit-watch`) ships separately.