### PR TITLE
fix(readme): show a visual for the demo instead of a naked URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,23 @@ Runs on your machine. Forward to Loki, Elastic, or Splunk only if you want to.</
 
 <div align="center">
 
-https://github.com/blitzcrieg1/agentmetry/releases/download/demo-assets/agentmetry.mp4
+<!--
+  DEMO VIDEO. GitHub renders an inline player only for assets it hosts itself
+  (github.com/user-attachments/assets/...), which are created by dragging the
+  file into the web editor. Release, raw and blob URLs all serve the MP4 as
+  application/octet-stream, so they download instead of playing. Until the
+  upload is done, this is a poster that links to the file.
+  To upgrade this block to a real player, see docs/readme-media.md
+-->
+
+<a href="https://github.com/blitzcrieg1/agentmetry/releases/download/demo-assets/agentmetry.mp4">
+  <img src="docs/assets/dashboard-detection.png" alt="Agentmetry dashboard: a CRITICAL credential-exfil detection correlating a read of ~/.ssh/id_rsa (T1552.004) with a WebFetch egress (T1071.001), shown live in the event feed." width="880">
+</a>
+
+<p>
+  <a href="https://github.com/blitzcrieg1/agentmetry/releases/download/demo-assets/agentmetry.mp4"><strong>Download the dashboard demo (MP4, 0.8 MB)</strong></a>
+  or run it locally with <code>python scripts/demo_dashboard.py</code>
+</p>
 
 <p><em>Event stream, detections strip, and live feed: every tool call tagged with MITRE ATT&amp;CK, with <strong>correlated CRITICAL alerts</strong> when a sequence adds up to an attack.</em></p>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,7 +55,9 @@ item matters to you.
 - **Windows one-flow install** — `scripts/install.ps1` (venv, dashboard deps,
   IDE hooks, doctor).
 - **Visual truth** — README, agentmetry.ai, and `docs/assets/agentmetry.mp4` match Phase 1
-  dashboard and live demo output.
+  dashboard and live demo output. The README hero is a poster image linking to the
+  MP4: GitHub only plays videos it hosts itself, so an inline player needs a
+  one-time web-editor upload ([docs/readme-media.md](docs/readme-media.md)).
 
 - **Phase 0 complete** — README SIEM-first + Advanced runtime doc; dogfood issue template.
 - **Tool allow/deny policy YAML** — `policies/tool/manifest.yaml`; hook `log`/`block` via

--- a/docs/readme-media.md
+++ b/docs/readme-media.md
@@ -1,0 +1,29 @@
+# Refreshing the README demo video
+
+GitHub renders an inline `<video>` player only for assets it hosts itself
+(`github.com/user-attachments/assets/<uuid>`). These are created by the web
+editor, not by any API or CLI, so the upload is a manual one-time step.
+
+Verified as non-working (all serve `application/octet-stream`, so the browser
+downloads instead of playing):
+
+| Source | Result |
+|--------|--------|
+| `<video src="docs/assets/agentmetry.mp4">` | stripped by the HTML sanitizer |
+| Release asset URL | `Content-Disposition: attachment` |
+| `raw.githubusercontent.com` URL | `application/octet-stream` |
+| Blob view (`/blob/master/...mp4`) | shows "Download raw file", no player |
+
+## Upgrading the poster to a real inline player
+
+1. Open `README.md` on github.com and click the pencil (Edit).
+2. Drag `docs/assets/agentmetry.mp4` into the editor. GitHub uploads it and
+   inserts a `https://github.com/user-attachments/assets/<uuid>` URL.
+3. Replace the poster `<a>`/`<img>` block with that bare URL on its own line.
+4. Preview to confirm a player appears, then commit.
+
+## When the video changes
+
+Re-record, replace `docs/assets/agentmetry.mp4`, refresh the release asset with
+`gh release upload demo-assets docs/assets/agentmetry.mp4 --clobber`, then redo
+the drag-and-drop above so the player points at the new file.


### PR DESCRIPTION
## The problem

The README hero rendered the release URL as plain link text. A visitor landing on the repo saw a URL string where the product shot belongs.

## Why no `<video>` pattern can work

Verified each route with `curl -sIL`:

| Route | Result |
|---|---|
| `<video src="docs/assets/agentmetry.mp4">` | stripped by GitHub's HTML sanitizer |
| Release asset URL | 302 to a CDN with `Content-Disposition: attachment`, `application/octet-stream` |
| `raw.githubusercontent.com` | `Content-Type: application/octet-stream` |
| Blob view `/blob/master/...mp4` | no player, shows "Download raw file" |

GitHub renders an inline player only for assets it hosts itself (`github.com/user-attachments/assets/<uuid>`), minted by the web editor's upload flow. That endpoint is CSRF-protected with no public API and no `gh` command, so **it cannot be automated**. This is a property of GitHub, not of the markup, which is why every previous attempt failed.

## What this ships

The poster fallback the brief specifies: the detection screenshot, centered and linked to the MP4, plus the local command as a second option. An HTML comment above the block records why, pointing at the new `docs/readme-media.md`. `ROADMAP.md` visual-truth line updated to describe the mechanism.

**What a visitor now sees:** immediately under the badges and nav, a full-width dashboard screenshot showing the CRITICAL credential-exfil detection with the `cat ~/.ssh/id_rsa` (T1552.004) → `WebFetch` (T1071.001) chain visible in the feed. Under it, a bold "Download the dashboard demo (MP4, 0.8 MB)" link and "or run it locally with `python scripts/demo_dashboard.py`", then the existing caption. No naked URL anywhere.

## One-time step to get a real player

Only you can do this (30 seconds):

1. Open `README.md` on github.com, click the pencil icon.
2. Drag `docs/assets/agentmetry.mp4` into the edit box. GitHub uploads it and inserts a `user-attachments` URL.
3. Replace the poster `<a>`/`<img>` block with that bare URL on its own line.
4. Preview to confirm the player renders, then commit.

`docs/readme-media.md` records this plus the refresh procedure when the video changes.

## Notes

- Did **not** convert the MP4 to GIF. The poster satisfies "show a visual", so the last-resort condition was not met.
- `docs/assets/dashboard-detection.png` is now used twice (hero poster and the artifact section). Acceptable, but swapping the artifact-section image to `dashboard.png` would remove the repetition.