### PR TITLE
docs: correct the places the project overstated itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,15 +130,24 @@ you configure them, so you do not need the dashboard open to get paged.
 
 ### See the dashboard with a story in it
 
+The dashboard is a static export, and it is not checked into the repo, so build
+it once first:
+
+```bash
+cd apps/dashboard && npm install && npm run build && cd ../..
+```
+
 ```bash
 python scripts/demo_dashboard.py            # seeds 7 sessions + 5 detections, serves http://127.0.0.1:8010/
 python scripts/demo_dashboard.py --live     # ...and streams synthetic agent traffic in real time
 ```
 
-One command seeds a realistic demo trail and serves the dashboard locally — no
-API key, no cloud. Seven sessions, five real detections (computed by the pipeline,
+That seeds a realistic demo trail and serves the dashboard locally, with no API
+key and no cloud. Seven sessions, five real detections (computed by the pipeline,
 not hand-written). The feed shows approval gates, tool calls, and inline detection
-events across Event stream, Detections, and Analytics tabs.
+events across Event stream, Detections, and Analytics tabs. Without the build step
+the script still seeds the trail and serves the API, and it will tell you the
+dashboard export is missing.
 
 See the [dashboard tour](docs/dashboard-tour.md) for what each view shows and how
 to read it.
@@ -224,6 +233,11 @@ agentmetry verify --trail apps\orchestrator\data\audit-forward.jsonl
 ```
 
 **What the chain does and does not prove.** Verification catches in-place edits, inserted or reordered lines, and forged appends, and it cross-checks the `.chain` sidecar to catch a truncated file. It cannot, by itself, prove the newest lines were not deleted along with the sidecar: any actor with full write access to the trail can also rewrite the sidecar. For that, `verify` prints the current chain head (sequence number plus SHA-256). Record it somewhere the audited agent cannot write (a git commit, a note, a password manager entry) and compare on the next verify.
+
+Two scope limits worth stating plainly:
+
+- **Only lines written after chaining was enabled are covered.** A trail that predates it keeps its earlier lines as a legacy unchained prefix, and `verify` reports them separately rather than vouching for them. On a long-running install most of the file can be legacy, so read the chained/legacy counts in the verify output, not just the `OK`.
+- **The chain protects the JSONL, not the dashboard.** The dashboard reads a SQLite index derived from the same canonical events. The two agree in practice, but the index carries no chain: the JSONL is the artifact you hand to an incident responder.
 
 ---
 
@@ -325,7 +339,12 @@ Every run emits typed, SIEM-ready JSON. A single `tool_called` line:
     "server": "vault_fs",
     "input_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     "parameters_redacted": true,
-    "mitre": {"tactic": "Collection (TA0009)", "technique": "Data from Local System (T1005)"}
+    "mitre": {
+      "tactic_id": "TA0009",
+      "tactic": "Collection",
+      "technique_id": "T1005",
+      "technique": "Data from Local System"
+    }
   },
   "model": {"id": "claude-3-5-sonnet", "provider": "anthropic"}
 }

--- a/apps/orchestrator/cli/__init__.py
+++ b/apps/orchestrator/cli/__init__.py
@@ -561,6 +561,15 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # A Windows console defaults to cp1252 and cannot encode the dashes this CLI
+    # prints, so `verify --trail` rendered as "OK ? 422 chained line(s)". That is
+    # the flagship trust command; it must not look broken on the primary dogfood
+    # platform. Same guard as scripts/demo.py.
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[union-attr]
+    except Exception:  # pragma: no cover - depends on the host console
+        pass
+
     parser = argparse.ArgumentParser(prog="agentmetry", description="Agentmetry local ops")
     parser.add_argument("--port", type=int, default=8000)
     sub = parser.add_subparsers(dest="command", required=True)

--- a/docs/agentmetry-event-schema.md
+++ b/docs/agentmetry-event-schema.md
@@ -59,6 +59,18 @@ AGENTMETRY_SPLUNK_HEC_TOKEN=...
 | `gated_action` | `approval_request` | Binds the gate to `{tool, server, input_hash}` |
 | `dlp` | `tool_called` (when `outcome` is `denied` or `mode` is `log`) | Records DLP scanner matches: `{rule_id, mode, pattern_type}` |
 | `actor.type` | Derived | `user` for human-initiated runs; `agent` for cron/vault/ingress |
+| `tool.mitre` | `tool_called` for a tool with an ATT&CK mapping | `{tactic_id, tactic, technique_id, technique}` |
+| `tool_policy` | `tool_called` / `approval_request` when an allow/deny rule matches | `{rule_id, action, mode, blocked}` |
+| `detection` | `action.type: detection` | Correlated finding: `{rule_id, title, severity, summary, correlation_id, tactic_ids, technique_ids, event_ids, first_seen_utc, last_seen_utc}` |
+
+**Note on MITRE**: the object carries both machine ids and human names. Write SIEM
+queries against `tactic_id` / `technique_id`; `tactic` / `technique` are display
+labels and their wording can change. There is no single combined field.
+
+**Note on detections**: a firing rule is emitted as its own canonical event with
+`action.type: detection`, and `action.outcome` carries the severity, so a SIEM can
+alert on `action.type:detection AND action.outcome:critical` without knowing
+Agentmetry's rule vocabulary.
 
 `initiator.actor_type` is set at `run_skill` from the call site (`manual`, `cron`, `vault_watch`, `ingress`, …) — never from client headers. `approval_response` events keep the run's `initiator` but set `actor.type=user` (the operator who clicked approve/reject).
 
@@ -86,7 +98,13 @@ AGENTMETRY_SPLUNK_HEC_TOKEN=...
     "server": "vault_fs",
     "input_redaction": "hash",
     "input_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    "parameters_redacted": true
+    "parameters_redacted": true,
+    "mitre": {
+      "tactic_id": "TA0009",
+      "tactic": "Collection",
+      "technique_id": "T1005",
+      "technique": "Data from Local System"
+    }
   },
   "model": {"id": "gemini-2.5-flash-lite", "provider": "gemini"}
 }


### PR DESCRIPTION
Four verified drift items from the post-launch audit. Docs and one encoding fix, no behaviour change.

## 1. The canonical event example showed a field that does not exist

`README.md` showed:

```json
"mitre": {"tactic": "Collection (TA0009)", "technique": "Data from Local System (T1005)"}
```

Nothing ever emits a combined id-and-name field. Real output has four separate keys, verified against `get_mitre_mapping`:

```json
"mitre": {"tactic_id": "TA0009", "tactic": "Collection", "technique_id": "T1005", "technique": "Data from Local System"}
```

The README **contradicted itself**: the JSONL sample earlier on the page already used `tactic_id`. This is the example directly under "The canonical event", so it is what a SIEM integrator copies.

## 2. The "full schema" doc never documented the MITRE object

`docs/agentmetry-event-schema.md` is linked from the README as the schema reference, but grepping it for `mitre` returned nothing. Added `tool.mitre`, `tool_policy` and `detection` to the v1.1 additions table, plus:

- query `tactic_id` / `technique_id`, not the display names, which can be reworded
- detections arrive as their own canonical event with the severity in `action.outcome`, so a SIEM can alert without knowing the rule vocabulary

## 3. `demo_dashboard.py` cannot serve a dashboard on a fresh clone

The script checks for `apps/dashboard/out/index.html`; `.gitignore:18` ignores that directory, so **no fresh clone has it**. The README promoted the command as serving a dashboard with no mention of a build. Added the build step and stated what happens without it (the trail seeds and the API serves, and the script tells you the export is missing).

## 4. `verify --trail` printed mojibake on Windows

```
OK ? 422 chained line(s) verified
```

The CLI never reconfigured stdout to UTF-8 the way `scripts/demo.py:52` already does. This is the flagship trust command on the primary dogfood platform.

Root cause is the encoding, not the characters, so the fix is one `try/except` at the CLI entry mirroring the existing pattern, rather than rewriting 16 strings. Verified after:

```
OK — 425 chained line(s) verified; 4521 legacy unchained prefix line(s)
  head: seq 425, sha256 7fae0ce4...
```

## Also: two chain scope limits stated next to the claim

- Only lines written after chaining was enabled are covered. On a long-running install most of the file can be legacy prefix, so read the chained/legacy counts rather than just the `OK`.
- The chain protects the JSONL, not the SQLite index the dashboard reads. The JSONL is the artifact you hand an incident responder.

310 passed, ruff clean (including `cli`).

Independent of #14 and #15; touches a different region of the README than #15.