### PR TITLE
docs: play-affordance label on the demo poster

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Runs on your machine. Forward to Loki, Elastic, or Splunk only if you want to.</
 </a>
 
 <p>
-  <a href="https://github.com/blitzcrieg1/agentmetry/releases/download/demo-assets/agentmetry.mp4"><strong>Download the dashboard demo (MP4, 0.8 MB)</strong></a>
+  <a href="https://github.com/blitzcrieg1/agentmetry/releases/download/demo-assets/agentmetry.mp4"><strong>▶ Watch the dashboard demo (MP4, 0.8 MB)</strong></a>
   or run it locally with <code>python scripts/demo_dashboard.py</code>
 </p>
 


### PR DESCRIPTION
Carries the better wording from the closed #13 onto master.

#15 merged at `128dc89`, one commit before I pushed this label change, so the branch had it but master did not. The comment I left when closing #13 said the label was already in #15, which was not true of master. This makes it true.

**Before:** "Download the dashboard demo (MP4, 0.8 MB)"
**After:** "▶ Watch the dashboard demo (MP4, 0.8 MB)"

The play glyph signals video far more clearly than a download verb, and the poster is the first thing a visitor sees. Size hint and the run-it-locally alternative are kept, so the link still tells the truth about what clicking does.

One line. Hero HTML verified still balanced (`<div>` 2/2, `<p>` 7/7).