### PR TITLE
docs: real inline video player in the README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,24 +34,17 @@ Runs on your machine. Forward to Loki, Elastic, or Splunk only if you want to.</
 <div align="center">
 
 <!--
-  DEMO VIDEO. GitHub renders an inline player only for assets it hosts itself
-  (github.com/user-attachments/assets/...), which are created by dragging the
-  file into the web editor. Release, raw and blob URLs all serve the MP4 as
-  application/octet-stream, so they download instead of playing. Until the
-  upload is done, this is a poster that links to the file.
-  To upgrade this block to a real player, see docs/readme-media.md
+  DEMO VIDEO. Keep the line below a bare github.com/user-attachments URL on its
+  own line. That is the only form GitHub renders as an inline player: release,
+  raw and blob URLs serve the MP4 as application/octet-stream and download
+  instead of playing, and <video src="docs/assets/..."> is stripped by the HTML
+  sanitizer. To replace the video, see docs/readme-media.md
 -->
 
-<a href="https://github.com/blitzcrieg1/agentmetry/releases/download/demo-assets/agentmetry.mp4">
-  <img src="docs/assets/dashboard-detection.png" alt="Agentmetry dashboard: a CRITICAL credential-exfil detection correlating a read of ~/.ssh/id_rsa (T1552.004) with a WebFetch egress (T1071.001), shown live in the event feed." width="880">
-</a>
+https://github.com/user-attachments/assets/edd2002e-47c1-4885-8500-b3651f648018
 
-<p>
-  <a href="https://github.com/blitzcrieg1/agentmetry/releases/download/demo-assets/agentmetry.mp4"><strong>▶ Watch the dashboard demo (MP4, 0.8 MB)</strong></a>
-  or run it locally with <code>python scripts/demo_dashboard.py</code>
-</p>
-
-<p><em>Event stream, detections strip, and live feed: every tool call tagged with MITRE ATT&amp;CK, with <strong>correlated CRITICAL alerts</strong> when a sequence adds up to an attack.</em></p>
+<p><em>Event stream, detections strip, and live feed: every tool call tagged with MITRE ATT&amp;CK, with <strong>correlated CRITICAL alerts</strong> when a sequence adds up to an attack.</em><br/>
+Run it yourself with <code>python scripts/demo_dashboard.py</code></p>
 
 </div>
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,9 +55,9 @@ item matters to you.
 - **Windows one-flow install** — `scripts/install.ps1` (venv, dashboard deps,
   IDE hooks, doctor).
 - **Visual truth** — README, agentmetry.ai, and `docs/assets/agentmetry.mp4` match Phase 1
-  dashboard and live demo output. The README hero is a poster image linking to the
-  MP4: GitHub only plays videos it hosts itself, so an inline player needs a
-  one-time web-editor upload ([docs/readme-media.md](docs/readme-media.md)).
+  dashboard and live demo output. The README hero plays inline on GitHub via a
+  `user-attachments` URL; refreshing it is a manual upload
+  ([docs/readme-media.md](docs/readme-media.md)).
 
 - **Phase 0 complete** — README SIEM-first + Advanced runtime doc; dogfood issue template.
 - **Tool allow/deny policy YAML** — `policies/tool/manifest.yaml`; hook `log`/`block` via

--- a/docs/readme-media.md
+++ b/docs/readme-media.md
@@ -1,29 +1,45 @@
 # Refreshing the README demo video
 
-GitHub renders an inline `<video>` player only for assets it hosts itself
-(`github.com/user-attachments/assets/<uuid>`). These are created by the web
-editor, not by any API or CLI, so the upload is a manual one-time step.
+The README hero is a real inline player. It works because the URL points at an
+asset GitHub hosts itself:
 
-Verified as non-working (all serve `application/octet-stream`, so the browser
-downloads instead of playing):
+```
+https://github.com/user-attachments/assets/<uuid>
+```
+
+Keep that line **bare and on its own line**. Wrapping it in an `<a>`, an `<img>`,
+or markdown link syntax turns it back into a plain link. GitHub rewrites the bare
+URL into a `<video controls>` element pointing at a signed
+`private-user-images.githubusercontent.com` URL served as `video/mp4`.
+
+`user-attachments` URLs are minted by GitHub's web upload. There is no API or
+`gh` command for it, so refreshing the video is a manual browser step.
+
+Verified as non-working, so nobody retries them (all serve
+`application/octet-stream`, so the browser downloads instead of playing):
 
 | Source | Result |
 |--------|--------|
 | `<video src="docs/assets/agentmetry.mp4">` | stripped by the HTML sanitizer |
-| Release asset URL | `Content-Disposition: attachment` |
+| Release asset URL | 302 to a CDN with `Content-Disposition: attachment` |
 | `raw.githubusercontent.com` URL | `application/octet-stream` |
 | Blob view (`/blob/master/...mp4`) | shows "Download raw file", no player |
 
-## Upgrading the poster to a real inline player
+## Replacing the video
 
-1. Open `README.md` on github.com and click the pencil (Edit).
-2. Drag `docs/assets/agentmetry.mp4` into the editor. GitHub uploads it and
-   inserts a `https://github.com/user-attachments/assets/<uuid>` URL.
-3. Replace the poster `<a>`/`<img>` block with that bare URL on its own line.
-4. Preview to confirm a player appears, then commit.
+1. Re-record and overwrite `docs/assets/agentmetry.mp4`.
+2. Refresh the release copy (used by the site and by direct links):
+   `gh release upload demo-assets docs/assets/agentmetry.mp4 --clobber`
+3. Open a new issue draft on github.com and drag the new MP4 into the comment
+   box. Wait for the upload, copy the `user-attachments` URL it inserts, then
+   close the tab without submitting. The asset stays uploaded.
+4. Swap that URL into the README hero line and open a PR.
 
-## When the video changes
+To confirm the player renders on a branch before merging:
 
-Re-record, replace `docs/assets/agentmetry.mp4`, refresh the release asset with
-`gh release upload demo-assets docs/assets/agentmetry.mp4 --clobber`, then redo
-the drag-and-drop above so the player points at the new file.
+```bash
+curl -sL https://github.com/<owner>/<repo>/blob/<branch>/README.md | grep -o '<video[^>]*>'
+```
+
+A `<video ... controls="controls" ...>` match means the player is live. Text
+extraction tools show only the filename, so they cannot confirm this.


### PR DESCRIPTION
The MP4 is now uploaded through GitHub's web editor, which mints a `user-attachments` URL. That is the only form GitHub renders as an inline player, so the poster fallback is retired.

## Verified rendering, not assumed

Text-extraction tools report a `<video>` element as just its filename, so they cannot confirm this. Checking the actual server HTML on the branch:

```bash
curl -sL https://github.com/blitzcrieg1/agentmetry/blob/docs/readme-inline-video/README.md \
  | grep -o '<video[^>]*>'
```

returns:

```html
<video src="https://private-user-images.githubusercontent.com/.../edd2002e-...mp4?jwt=..."
       controls="controls" muted="muted"
       class="d-block rounded-bottom-2 border-top width-fit"
       style="max-height:640px; min-height: 200px">
```

`controls="controls"` confirms playback controls, and the signed URL carries `response-content-type=video/mp4`, so it is served as real video rather than the `application/octet-stream` every other route returned. It also renders correctly **inside** the `<div align="center">`, which was the open question.

## What changed

- Hero is now a bare `user-attachments` URL on its own line. A comment above it records that it must stay bare: wrapping it in `<a>` or `<img>` turns it back into a link, which is exactly how this broke before.
- `docs/readme-media.md` rewritten for the shipped state, keeping the table of non-working sources so nobody retries release/raw/blob URLs. Adds the `curl | grep '<video'` check.
- `ROADMAP.md` visual-truth line updated.

The dashboard screenshot still appears in the JSONL-vs-dashboard section, so renderers without video support keep a visual.

Hero HTML verified balanced (`<div>` 2/2, `<p>` 6/6).