### PR TITLE
fix(ingest): bind an inferred approval to the action that was approved

### DIFF
--- a/apps/orchestrator/core/audit/ingest.py
+++ b/apps/orchestrator/core/audit/ingest.py
@@ -44,6 +44,27 @@ def _tool_ident(canonical: dict[str, Any]) -> tuple[str, str, str]:
     )
 
 
+def _approval_matches(pending: dict[str, str], qualified: str, input_hash: str) -> bool:
+    """Does this executed call satisfy that pending approval?
+
+    Bind on the most specific identity both sides carry, the same precedence
+    rule_approval_denied_then_executed uses. When both know the argument hash
+    they must agree: an approval for `Bash(rm -rf /tmp/x)` must not be consumed
+    by a later `Bash(ls)`, or the trail claims a human approved something they
+    never saw. That gap between the proposed action and the one that ran is
+    exactly where surprises live.
+
+    Falls back to the tool name only when a hash is missing on either side,
+    which is the pre-hash adapter case. An approval recorded with no tool name
+    still matches anything, as before.
+    """
+    if pending.get("tool") and pending["tool"] != qualified:
+        return False
+    if pending.get("input_hash") and input_hash:
+        return pending["input_hash"] == input_hash
+    return True
+
+
 def _approval_payload(
     source_app: str, corr: str, pending: dict[str, str], outcome: str, reason: str
 ) -> dict[str, Any]:
@@ -81,9 +102,9 @@ def infer_approval_payloads(canonical: dict[str, Any]) -> list[dict[str, Any]]:
 
     if atype == "tool_called" and outcome == "success":
         bucket = _pending_approvals.get(corr) or []
-        qualified, _server, _hash = _tool_ident(canonical)
+        qualified, _server, input_hash = _tool_ident(canonical)
         for i, pending in enumerate(bucket):
-            if not pending["tool"] or pending["tool"] == qualified:
+            if _approval_matches(pending, qualified, input_hash):
                 bucket.pop(i)
                 return [
                     _approval_payload(

--- a/apps/orchestrator/tests/test_external_ingest.py
+++ b/apps/orchestrator/tests/test_external_ingest.py
@@ -179,6 +179,98 @@ def test_infer_grant_on_tool_run_after_ask():
     assert inferred[0]["gated_action"]["tool"] == "shell.run"
 
 
+def _ask(corr: str, tool: str = "shell.run", input_hash: str | None = None) -> dict:
+    payload: dict = {
+        "source_app": "cursor", "event_type": "approval_request", "outcome": "pending",
+        "correlation_id": corr,
+        "tool": {"qualified": tool, "server": "shell"},
+    }
+    if input_hash:
+        payload["tool"]["input_hash"] = input_hash
+    return build_external_canonical(payload)
+
+
+def _ran(corr: str, tool: str = "shell.run", input_hash: str | None = None) -> dict:
+    payload: dict = {
+        "source_app": "cursor", "event_type": "tool_called", "outcome": "success",
+        "correlation_id": corr,
+        "tool": {"qualified": tool, "server": "shell"},
+    }
+    if input_hash:
+        payload["tool"]["input_hash"] = input_hash
+    return build_external_canonical(payload)
+
+
+def test_approval_not_consumed_by_a_different_command_on_the_same_tool():
+    """Approve `Bash(rm -rf /tmp/x)`, run `Bash(ls)`: that is NOT the approved action.
+
+    The matcher used to compare tool names only, so any later call to the same
+    tool silently consumed the approval and the trail asserted a human had
+    approved something they never saw. This is the proposed-vs-executed gap.
+    """
+    reset_pending_approvals()
+    infer_approval_payloads(_ask("conv-mismatch", input_hash="a" * 64))
+
+    inferred = infer_approval_payloads(_ran("conv-mismatch", input_hash="b" * 64))
+    assert inferred == [], "a different command must not satisfy the approval"
+
+    # The approval was never satisfied, so it must still be pending and resolve
+    # as denied at session end rather than vanishing.
+    end = build_external_canonical({
+        "source_app": "cursor", "event_type": "session_end", "correlation_id": "conv-mismatch",
+    })
+    closed = infer_approval_payloads(end)
+    assert len(closed) == 1
+    assert closed[0]["outcome"] == "denied"
+    assert closed[0]["gated_action"]["input_hash"] == "a" * 64
+
+
+def test_approval_binds_when_the_hash_matches():
+    reset_pending_approvals()
+    infer_approval_payloads(_ask("conv-exact", input_hash="c" * 64))
+
+    inferred = infer_approval_payloads(_ran("conv-exact", input_hash="c" * 64))
+    assert len(inferred) == 1
+    assert inferred[0]["reason"] == "inferred:tool_ran_after_ask"
+    assert inferred[0]["gated_action"]["input_hash"] == "c" * 64
+
+
+def test_approval_falls_back_to_tool_name_when_a_hash_is_missing():
+    """Pre-hash adapters send no input_hash; name matching must still work."""
+    reset_pending_approvals()
+    infer_approval_payloads(_ask("conv-nohash"))
+
+    inferred = infer_approval_payloads(_ran("conv-nohash", input_hash="d" * 64))
+    assert len(inferred) == 1
+    assert inferred[0]["reason"] == "inferred:tool_ran_after_ask"
+
+
+def test_approval_for_one_tool_is_not_consumed_by_another():
+    reset_pending_approvals()
+    infer_approval_payloads(_ask("conv-tools", tool="shell.run", input_hash="e" * 64))
+
+    assert infer_approval_payloads(_ran("conv-tools", tool="fs.write", input_hash="e" * 64)) == []
+
+
+def test_matching_approval_is_found_past_an_unrelated_pending_one():
+    """The right approval binds even when a mismatched one is queued ahead of it."""
+    reset_pending_approvals()
+    infer_approval_payloads(_ask("conv-queue", input_hash="1" * 64))
+    infer_approval_payloads(_ask("conv-queue", input_hash="2" * 64))
+
+    inferred = infer_approval_payloads(_ran("conv-queue", input_hash="2" * 64))
+    assert len(inferred) == 1
+    assert inferred[0]["gated_action"]["input_hash"] == "2" * 64
+
+    # The first approval is untouched and still resolves as denied.
+    end = build_external_canonical({
+        "source_app": "cursor", "event_type": "session_end", "correlation_id": "conv-queue",
+    })
+    closed = infer_approval_payloads(end)
+    assert len(closed) == 1
+    assert closed[0]["gated_action"]["input_hash"] == "1" * 64
+
+
 def test_infer_denied_on_session_end_pending():
     """ask still pending at session end ⇒ inferred denied (F2)."""
     reset_pending_approvals()


### PR DESCRIPTION
## The bug

`infer_approval_payloads` matched a pending approval to an executed call by **tool name only**. It even unpacked the executed hash and then discarded it:

```python
qualified, _server, _hash = _tool_ident(canonical)   # _hash never used
for i, pending in enumerate(bucket):
    if not pending["tool"] or pending["tool"] == qualified:
```

So an approval for `Bash(rm -rf /tmp/x)` was silently consumed by a later `Bash(ls)`, and the trail then asserted a human had approved an action they never saw. For a tool whose central claim is recording *what the human approved*, that is the wrong thing to be wrong about.

This is the "diff between what the agent proposed and what actually ran" gap raised in the r/ClaudeAI feedback. The **denial** path already bound by hash (`rules.py:350-374`); the **approval** path did not.

## The fix

Match on the most specific identity both sides carry, mirroring the precedence `rule_approval_denied_then_executed` already uses:

1. tool name must agree (unchanged)
2. if **both** sides carry an `input_hash`, they must be equal
3. otherwise fall back to name only, for pre-hash adapters

An approval recorded with no tool name still matches anything, as before.

## What a mismatch now produces

The approval is **not** consumed, so it stays pending and resolves as `inferred:session_ended_pending` (denied) at session end. The trail then shows both halves of the gap:

- an approval request that was never satisfied, carrying the proposed `input_hash`
- a successful tool call carrying a different hash and no approval

That is the proposed-versus-executed diff recorded honestly, and it means `autonomous-unapproved-write` can fire on the call that actually ran instead of being masked by a bogus approval.

## Tests

Five cases in `test_external_ingest.py`: exact-hash bind, mismatch on the same tool, name fallback when a hash is absent, cross-tool isolation, and finding the correct approval past a queued mismatched one.

Verified they catch the regression: restoring the old name-only matcher fails exactly the two tests that pin the new behaviour, while the other twelve still pass (so existing semantics are preserved).

319 passed, ruff clean.