### PR TITLE
test: use neutral Windows path in ingest client fixture

### DIFF
--- a/apps/orchestrator/tests/test_agentmetry_ingest_client.py
+++ b/apps/orchestrator/tests/test_agentmetry_ingest_client.py
@@ -71,7 +71,7 @@ def test_antigravity_v2_pre_tool_use_run_command(monkeypatch):
             "name": "run_command",
             "args": {
                 "CommandLine": "Get-Process | Sort-Object CPU -Descending | Select-Object -First 5",
-                "Cwd": r"C:\Users\spiro\.gemini\antigravity\scratch",
+                "Cwd": r"C:\Users\testuser\.gemini\antigravity\scratch",
             },
         },
         "conversationId": "ec33ebf9-0cba-4100-8142-c61503f6c587",


### PR DESCRIPTION
## Summary

- Replace the hardcoded developer username in the Windows path fixture with a neutral username (`testuser`).
- Verified there are no other hardcoded developer usernames in `apps/orchestrator/tests/`.

## Testing

```bash
cd apps/orchestrator
pytest tests/test_agentmetry_ingest_client.py -q