### PR TITLE
chore(security): scan our own supply chain, and close the five silent swallows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,65 @@
+version: 2
+
+# A tool that inspects other people's supply chains had no view of its own. The
+# MSI ships a frozen Python environment, so a CVE in a transitive dependency
+# reaches a customer machine inside our binary with nothing in the path to catch
+# it, and "we would have noticed" is not a control.
+#
+# Weekly rather than daily on purpose. A solo maintainer who opens Monday to
+# eleven bot PRs stops reading them, and a Dependabot queue nobody reads is
+# worse than none: it looks like coverage.
+
+updates:
+  # --- Python: the recorder itself -----------------------------------------
+  - package-ecosystem: pip
+    directory: /apps/orchestrator
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Europe/Athens
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps(dev)"
+    groups:
+      # One PR for the routine bumps, so the ones worth reading stand out.
+      # Security updates are deliberately not grouped: Dependabot raises those
+      # separately regardless, and a security fix buried in a nine-package PR
+      # is a security fix that waits for the rest of the PR to be reviewed.
+      patch-and-minor:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # --- Node: the dashboard --------------------------------------------------
+  - package-ecosystem: npm
+    directory: /apps/dashboard
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Europe/Athens
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+    commit-message:
+      prefix: "deps"
+    groups:
+      patch-and-minor:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # --- The workflows themselves --------------------------------------------
+  # A pinned action is a dependency with code execution in a job that holds an
+  # OIDC token good enough to publish to PyPI. This is the highest-value
+  # ecosystem on the list and the easiest one to forget exists.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Europe/Athens
+    labels: ["dependencies", "ci"]
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ on:
 #   dashboard
 #   CLAAssistant           <- from cla.yml, not this file
 #
+# Deliberately NOT required: `supply-chain` here, and `analyze` in codeql.yml.
+# Both report on the world rather than on the diff, so a CVE published overnight
+# would block a docs typo through no change of ours. A red X the maintainer
+# reads is worth more than a blocking gate the maintainer learns to bypass.
+#
 # Read them back with:
 #   gh api repos/blitzcrieg1/agentmetry/branches/master/protection/required_status_checks --jq .contexts
 jobs:
@@ -110,6 +115,40 @@ jobs:
             }
           }
           if ($failed) { exit 1 }
+
+  supply-chain:
+    # Nothing here inspects the diff. It asks whether anything the recorder
+    # already depends on has since been found vulnerable, which is a question
+    # whose answer changes without anybody touching this repository. That is
+    # also why it runs on a schedule rather than only on push.
+    #
+    # The MSI ships a frozen Python environment, so a CVE in a transitive
+    # dependency reaches a customer machine inside our binary. "We would have
+    # noticed" is not a control, and a tool that inspects other people's supply
+    # chains having no view of its own is the first thing a security buyer asks
+    # about and the worst one to have no answer for.
+    name: supply-chain
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/orchestrator
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install orchestrator
+        run: |
+          # pip audits itself, and a runner's bundled pip is routinely a few
+          # releases behind whatever advisory landed this month. Upgrading first
+          # keeps the finding list about our dependencies rather than about the
+          # installer that fetched them.
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Audit dependencies
+        run: |
+          python -m pip install --upgrade pip-audit
+          pip-audit --progress-spinner off --strict
 
   dashboard:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,64 @@
+name: CodeQL
+
+# Static analysis on the recorder and the dashboard.
+#
+# ruff's `S` rules (bandit) run in CI already and catch the per-line patterns:
+# a bare subprocess, a hardcoded credential, a swallowed exception. They do not
+# do interprocedural analysis, so a tainted value that arrives through three
+# function calls before it reaches a sink is invisible to them and visible to
+# this. The two overlap and neither replaces the other.
+#
+# Not a required status check, deliberately. CodeQL takes minutes rather than
+# seconds and its findings want reading rather than reacting to; blocking every
+# PR on it would teach the maintainer to merge past it. It runs on pushes, on
+# pull requests, and weekly so a newly published query finds old code.
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+  schedule:
+    # Monday 06:00 UTC, ahead of the Dependabot run, so a week's security
+    # reading arrives together rather than twice.
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # Writes results to the Security tab. Without this the run succeeds and
+      # publishes nothing, which looks exactly like a clean scan.
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # security-extended adds the lower-severity and higher-noise queries.
+          # Worth it here: the whole point is finding what the line-level linter
+          # cannot, and a security product can afford to read a few more
+          # findings than a CRUD app can.
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,3 +59,37 @@ Out of scope:
 - **Command logging is opt-in** (`AGENTMETRY_AUDIT_LOG_COMMANDS`). When enabled,
   shell command text is stored (after scrubbing). Leave it off if the commands
   themselves are sensitive.
+
+## How Agentmetry checks itself
+
+A tool that inspects other people's supply chains should be able to answer the
+same questions about its own. Every one of these runs in CI on each pull request
+and on master; none of it is a periodic manual pass.
+
+| Concern | Control | Where |
+|---|---|---|
+| Committed secrets | gitleaks over the pushed commit range | `ci.yml` |
+| Insecure code patterns | ruff `S` (bandit) and `B` (bugbear), zero findings | `ci.yml` |
+| Data flow a linter cannot follow | CodeQL `security-extended`, Python and TypeScript | `codeql.yml` |
+| Vulnerable dependencies | `pip-audit --strict` on the full resolved tree | `ci.yml` |
+| Dependency currency | Dependabot, weekly, including GitHub Actions | `dependabot.yml` |
+| Detection accuracy | 50-case benchmark, fails on any miss or false positive | `ci.yml`, `release.yml` |
+| Packaging | wheel installed into a clean environment; `doctor` must report no FAIL | `release.yml` |
+| Publication | PyPI Trusted Publishing (OIDC). No API token exists to leak | `release.yml` |
+
+Two of these are deliberately **not** required status checks: CodeQL and
+`pip-audit`. Both report on the world rather than on the diff, so a CVE
+published overnight would block an unrelated documentation fix. A visible red
+mark the maintainer reads is worth more than a blocking gate the maintainer
+learns to route around.
+
+Where a bandit finding is suppressed, the suppression carries the reasoning
+next to it rather than a bare `noqa`, and the two rules disabled project-wide
+(`S603`, `S607`, both about subprocess invocation) are argued in
+`apps/orchestrator/pyproject.toml`. If you think one of those arguments is
+wrong, that is worth an issue.
+
+What this does **not** include, stated plainly: there is no third-party
+penetration test, no SOC 2, no signed release artifact, and no reproducible
+build. The MSI is unsigned. Those are real gaps, not oversights, and they are
+the honest answer to a security questionnaire that asks.

--- a/apps/orchestrator/agentmetry/cli/__init__.py
+++ b/apps/orchestrator/agentmetry/cli/__init__.py
@@ -7,6 +7,7 @@ Pure stdlib + httpx; never imports the FastAPI app (fast startup, no side effect
 from __future__ import annotations
 
 import argparse
+import logging
 import os
 import shutil
 import socket
@@ -30,11 +31,13 @@ _TASK_NAME = "Agentmetry Orchestrator"
 # Paths bundled by backup, relative to the repo root.
 _BACKUP_PREFIXES = ("vault/", "apps/orchestrator/data/")
 _BACKUP_EXCLUDE_DIRS = {"logs"}
+logger = logging.getLogger(__name__)
+
 _BACKUP_EXCLUDE_SUFFIXES = {".pid"}
 
 
 def _base_url(port: int, host: str = "127.0.0.1") -> str:
-    display = host if host != "0.0.0.0" else "127.0.0.1"
+    display = host if host != "0.0.0.0" else "127.0.0.1"  # noqa: S104
     return f"http://{display}:{port}"
 
 
@@ -65,8 +68,12 @@ def _fetch_health(port: int) -> dict | None:
         resp = httpx.get(f"{_base_url(port)}/api/v1/health", timeout=10.0)
         if resp.status_code == 200:
             return resp.json()
-    except Exception:
-        pass
+    except Exception as exc:
+        # Not running is the expected answer here and `None` says so. Logged at
+        # debug anyway: a probe that fails for a reason other than "nothing is
+        # listening" (TLS, a proxy, a permission error) otherwise looks identical
+        # to a stopped orchestrator, and that is an hour of somebody's afternoon.
+        logger.debug("health probe on port %s failed: %s", port, exc)
     return None
 
 
@@ -77,7 +84,7 @@ def cmd_start(args: argparse.Namespace) -> int:
     host = getattr(args, "host", "127.0.0.1")
     if _fetch_health(args.port):
         print(f"Already running on {_base_url(args.port, host)}")
-        if host == "0.0.0.0":
+        if host == "0.0.0.0":  # noqa: S104
             _print_lan_hint(args.port)
         return 0
 
@@ -112,7 +119,7 @@ def cmd_start(args: argparse.Namespace) -> int:
     while time.monotonic() < deadline:
         if _fetch_health(args.port):
             print(f"Agentmetry running on {_base_url(args.port, host)} (pid {proc.pid})")
-            if host == "0.0.0.0":
+            if host == "0.0.0.0":  # noqa: S104
                 _print_lan_hint(args.port)
             return 0
         if proc.poll() is not None:
@@ -1055,7 +1062,12 @@ def main(argv: list[str] | None = None) -> int:
     # platform. Same guard as scripts/demo.py.
     try:
         sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[union-attr]
-    except Exception:  # pragma: no cover - depends on the host console
+    except Exception:  # noqa: S110  # pragma: no cover - host console dependent
+        # The one swallow with nowhere to swallow into: this runs before logging
+        # is configured, and the failure means the console cannot render UTF-8,
+        # which is also why a log line about it would not render. The fallback is
+        # the console's own encoding, which is what would have happened without
+        # the call.
         pass
 
     parser = argparse.ArgumentParser(prog="agentmetry", description="Agentmetry local ops")

--- a/apps/orchestrator/agentmetry/core/audit/detection/yaml_config.py
+++ b/apps/orchestrator/agentmetry/core/audit/detection/yaml_config.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 _ORCH_ROOT = Path(__file__).resolve().parents[4]
 _DEFAULT_MANIFEST = _ORCH_ROOT.parent.parent / "policies" / "detection" / "manifest.yaml"
@@ -35,8 +38,11 @@ def _manifest_path() -> Path:
         custom = settings.detection_rules_path
         if custom:
             return Path(custom)
-    except Exception:
-        pass
+    except Exception as exc:
+        # Falling back to the packaged manifest is correct, but doing it in
+        # silence means an operator who configured their own rules runs the
+        # default ones and is never told.
+        logger.debug("could not read detection_rules_path from settings: %s", exc)
     return _DEFAULT_MANIFEST
 
 

--- a/apps/orchestrator/agentmetry/core/audit/trail_anchor.py
+++ b/apps/orchestrator/agentmetry/core/audit/trail_anchor.py
@@ -46,6 +46,7 @@ a range and the tail is named as what it is: chain-verified, not anchored.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import platform
 from dataclasses import dataclass, field
@@ -54,6 +55,8 @@ from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 from agentmetry.core.audit.trail_merkle import merkle_root, read_leaves
+
+logger = logging.getLogger(__name__)
 
 ANCHOR_VERSION = 1
 ANCHOR_ALG = "rfc6962-sha256"
@@ -96,8 +99,13 @@ def resolve_anchor_log(
         configured = str(getattr(settings, "anchor_log_path", "") or "").strip()
         if configured:
             return Path(configured), "config"
-    except Exception:
-        pass
+    except Exception as exc:
+        # This one matters more than it looks. Falling back in silence means
+        # `verify` compares the trail against a log sitting beside it, which an
+        # attacker who rewrote one could rewrite as well. The operator configured
+        # an external anchor precisely to avoid that, and would never learn the
+        # setting was not read.
+        logger.debug("could not read anchor_log_path from settings: %s", exc)
     return anchor_path(Path(trail_path)), "default"
 
 
@@ -118,8 +126,8 @@ def default_host_id() -> str:
         configured = str(getattr(settings, "operator_id", "") or "").strip()
         if configured:
             return configured
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("could not read operator_id from settings: %s", exc)
     return platform.node() or "unknown-host"
 
 

--- a/apps/orchestrator/agentmetry/core/audit/trail_db.py
+++ b/apps/orchestrator/agentmetry/core/audit/trail_db.py
@@ -232,6 +232,13 @@ class AuditTrailDB:
         if before_utc and after_utc:
             raise ValueError("Use only one of before_utc or after_utc")
 
+        # The three f-string queries below are suppressed for S608. Every element
+        # of `clauses` is a literal built in this function, and the only
+        # interpolation inside one is `placeholders`, which is a run of "?".
+        # `focus` is validated against a closed set and raises on anything
+        # else. Every caller-supplied value reaches sqlite through `params`,
+        # never through the string. Adding a clause that interpolates a value
+        # would make the suppressions wrong, so add it as a "?" instead.
         where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
 
         conn = self._get_conn()
@@ -239,7 +246,7 @@ class AuditTrailDB:
         if before_utc:
             sql = f"""SELECT event_json FROM audit_events {where}
                       {"AND" if clauses else "WHERE"} timestamp_utc < ?
-                      ORDER BY timestamp_utc DESC, id DESC LIMIT ?"""
+                      ORDER BY timestamp_utc DESC, id DESC LIMIT ?"""  # noqa: S608
             params.extend([before_utc, limit + 1])
             rows = conn.execute(sql, params).fetchall()
             has_older = len(rows) > limit
@@ -248,7 +255,7 @@ class AuditTrailDB:
         elif after_utc:
             sql = f"""SELECT event_json FROM audit_events {where}
                       {"AND" if clauses else "WHERE"} timestamp_utc > ?
-                      ORDER BY timestamp_utc ASC, id ASC LIMIT ?"""
+                      ORDER BY timestamp_utc ASC, id ASC LIMIT ?"""  # noqa: S608
             params.extend([after_utc, limit + 1])
             rows = conn.execute(sql, params).fetchall()
             has_newer = len(rows) > limit
@@ -257,7 +264,7 @@ class AuditTrailDB:
         else:
             # Latest page: get last N rows
             sql = f"""SELECT event_json FROM audit_events {where}
-                      ORDER BY timestamp_utc DESC, id DESC LIMIT ?"""
+                      ORDER BY timestamp_utc DESC, id DESC LIMIT ?"""  # noqa: S608
             params.append(limit + 1)
             rows = conn.execute(sql, params).fetchall()
             has_older = len(rows) > limit

--- a/apps/orchestrator/agentmetry/core/bus/events.py
+++ b/apps/orchestrator/agentmetry/core/bus/events.py
@@ -20,7 +20,7 @@ ALERT_COST = "run/cost_alert"
 ALERT_DRIFT = "run/drift_alert"
 
 # High-volume, ephemeral — excluded from the outbox.
-LLM_TOKEN = "llm/token"
+LLM_TOKEN = "llm/token"  # noqa: S105  - an event topic name, not a credential
 
 # Vault
 VAULT_FILE_CHANGED = "vault/file_changed"

--- a/apps/orchestrator/agentmetry/core/diagnostics/doctor.py
+++ b/apps/orchestrator/agentmetry/core/diagnostics/doctor.py
@@ -59,7 +59,7 @@ def _check_health_endpoint(report: DoctorReport) -> None:
 
     url = settings.audit_ingest_url.rstrip("/") + "/api/v1/health"
     try:
-        with urllib.request.urlopen(url, timeout=2) as resp:
+        with urllib.request.urlopen(url, timeout=2) as resp:  # noqa: S310
             if resp.status == 200:
                 report.ok("orchestrator_up", f"Orchestrator responding at {url}")
                 return

--- a/apps/orchestrator/agentmetry/core/diagnostics/driver_paths.py
+++ b/apps/orchestrator/agentmetry/core/diagnostics/driver_paths.py
@@ -19,10 +19,12 @@ logger = logging.getLogger(__name__)
 _ORCH_ROOT = Path(__file__).resolve().parents[3]
 _REPO_ROOT = _ORCH_ROOT.parents[1]
 
-TOKEN_PYTHON = "{PYTHON}"
-TOKEN_ORCH = "{ORCHESTRATOR_ROOT}"
-TOKEN_REPO = "{REPO_ROOT}"
-TOKEN_VAULT = "{VAULT_PATH}"
+# noqa S105 on all four: these are path-substitution placeholders written into
+# portable driver specs, not credentials. The rule matches the variable name.
+TOKEN_PYTHON = "{PYTHON}"  # noqa: S105
+TOKEN_ORCH = "{ORCHESTRATOR_ROOT}"  # noqa: S105
+TOKEN_REPO = "{REPO_ROOT}"  # noqa: S105
+TOKEN_VAULT = "{VAULT_PATH}"  # noqa: S105
 
 _PORTABLE_TOKENS = (TOKEN_PYTHON, TOKEN_ORCH, TOKEN_REPO, TOKEN_VAULT)
 

--- a/apps/orchestrator/agentmetry/hooks/ingest.py
+++ b/apps/orchestrator/agentmetry/hooks/ingest.py
@@ -31,6 +31,7 @@ import json
 import os
 import re
 import sys
+import urllib.parse
 import urllib.request
 from urllib.error import URLError
 from datetime import datetime, timezone
@@ -77,16 +78,45 @@ CURSOR_BLOCKING = frozenset({
 })
 
 
+_DEFAULT_BASE_URL = "http://127.0.0.1:8000"
+# urlopen also speaks file:, ftp: and whatever else is registered. Only these
+# two are a recorder talking to its orchestrator.
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
 def _base_url() -> str:
-    return (
+    """The orchestrator base URL, with the scheme pinned to http or https.
+
+    `urlopen` speaks more than HTTP. A base URL of `file:///...` turns every
+    ingest POST into a local file read whose result is reported back through the
+    hook, and `AGENTMETRY_URL` is an environment variable, which on a developer
+    machine is not a hard thing to set. Reaching that requires code execution as
+    the operator already, so this is not the difference between safe and
+    exploited, but a recorder should not be the component that widens what an
+    attacker who is already there can reach.
+
+    An unusable scheme falls back to the loopback default rather than raising:
+    hooks run inside the IDE's tool path and must never be the reason a tool
+    call fails. The event still lands, on the default endpoint.
+    """
+    configured = (
         os.environ.get("AGENTMETRY_URL")
         or os.environ.get("AGENTMETRY_AUDIT_INGEST_URL")
-        or "http://127.0.0.1:8000"
+        or _DEFAULT_BASE_URL
     ).rstrip("/")
+    scheme = urllib.parse.urlparse(configured).scheme.lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        print(
+            f"Agentmetry: ignoring configured URL with unsupported scheme "
+            f"{scheme!r}; using {_DEFAULT_BASE_URL}",
+            file=sys.stderr,
+        )
+        return _DEFAULT_BASE_URL
+    return configured
 
 
 def _api_key() -> str:
@@ -498,15 +528,17 @@ def post_ingest(payload: dict[str, Any], *, quiet: bool = False, spool: bool = T
     # unrelated events, and misstated when things happened in a record whose
     # whole purpose is to say when things happened.
     payload.setdefault("timestamp_utc", _utc_now())
+    # S310 is suppressed on the Request/urlopen pair below because the scheme
+    # is pinned in `_base_url`, which is the check the rule is asking for.
     url = f"{_base_url()}/api/v1/audit/ingest"
     body = json.dumps(payload).encode("utf-8")
     headers = {"Content-Type": "application/json"}
     api_key = _api_key()
     if api_key:
         headers["X-API-Key"] = api_key
-    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")  # noqa: S310
     try:
-        with urllib.request.urlopen(req, timeout=_INGEST_TIMEOUT_SECONDS) as response:
+        with urllib.request.urlopen(req, timeout=_INGEST_TIMEOUT_SECONDS) as response:  # noqa: S310
             res_body = response.read().decode("utf-8")
             if response.status != 200:
                 print(f"Agentmetry ingest HTTP {response.status}: {res_body}")
@@ -537,8 +569,8 @@ def _get_tail(source_app: str, *, limit: int = 50) -> dict[str, Any]:
     api_key = _api_key()
     if api_key:
         headers["X-API-Key"] = api_key
-    req = urllib.request.Request(url, headers=headers, method="GET")
-    with urllib.request.urlopen(req, timeout=3) as resp:
+    req = urllib.request.Request(url, headers=headers, method="GET")  # noqa: S310
+    with urllib.request.urlopen(req, timeout=3) as resp:  # noqa: S310
         return json.loads(resp.read())
 
 

--- a/apps/orchestrator/pyproject.toml
+++ b/apps/orchestrator/pyproject.toml
@@ -91,7 +91,39 @@ target-version = "py311"
 # stable contract across releases, so an unstated selection makes lint results
 # depend on install date. These are ruff's classic defaults: pyflakes plus the
 # pycodestyle errors worth failing a build over.
-select = ["E4", "E7", "E9", "F"]
+# S is bandit and B is bugbear. A tool that inspects other people's supply
+# chains should run a security linter over its own, and "we did not have one"
+# is a bad answer to the first question a security buyer asks about the SDLC.
+select = ["E4", "E7", "E9", "F", "B", "S"]
+
+# Reviewed once, per rule, rather than sprinkled as inline noqa across forty
+# call sites. Anything not listed here is expected to be fixed, not silenced.
+ignore = [
+  # S603 fires on *every* subprocess call, including the safe form. Passing an
+  # argument list without shell=True is the mitigation, and this project spawns
+  # processes by design: schtasks to register autostart, python to launch the
+  # orchestrator, powershell for the installers. Ruff's own docs say the rule
+  # needs manual review rather than blanket action. It was reviewed: every call
+  # site passes a list built from our own constants and resolved paths.
+  "S603",
+  # S607 wants absolute paths for executables. The partial names here are
+  # Windows system binaries (schtasks, powershell, python) resolved through
+  # PATH, which is the conventional and portable form. Hardcoding
+  # C:\Windows\System32 would break on non-default installs and buy nothing
+  # against an attacker who can already write PATH for this user.
+  "S607",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests assert. That is the entire point of them, and S101 would fire 1,654
+# times. Everything else stays on in tests, including in production code where
+# a bare assert really is a finding.
+"tests/**" = [
+  "S101",  # assert
+  "S105",  # "token"-shaped fixture names holding no secret
+  "S106",  # same, passed as an argument
+  "S104",  # tests assert on the 0.0.0.0 handling; they do not bind it
+]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/apps/orchestrator/tests/test_agentmetry_ingest_client.py
+++ b/apps/orchestrator/tests/test_agentmetry_ingest_client.py
@@ -308,3 +308,50 @@ def test_hook_main_enforce_opt_in(monkeypatch, capsys):
     ingest.hook_main("beforeShellExecution")
     out = capsys.readouterr().out
     assert '"permission": "allow"' in out
+
+
+# --- base URL scheme pinning -----------------------------------------------
+#
+# `urlopen` speaks more than HTTP. `AGENTMETRY_URL=file:///etc/passwd` would
+# turn every ingest POST into a local file read reported back through the hook.
+# Reaching that needs code execution as the operator already, so it is hardening
+# rather than a patched vulnerability, but the recorder should not be the thing
+# that widens what an attacker already inside can reach.
+
+
+@pytest.mark.parametrize(
+    "configured",
+    ["http://127.0.0.1:9999", "https://collector.internal:8443", "http://host/sub"],
+)
+def test_http_and_https_base_urls_are_kept(monkeypatch, configured):
+    monkeypatch.setenv("AGENTMETRY_URL", configured)
+    assert ingest._base_url() == configured.rstrip("/")
+
+
+@pytest.mark.parametrize(
+    "configured",
+    [
+        "file:///etc/passwd",
+        "ftp://example.com/x",
+        "gopher://example.com",
+        "127.0.0.1:8000",  # no scheme at all
+    ],
+)
+def test_unsupported_schemes_fall_back_to_loopback(monkeypatch, capsys, configured):
+    monkeypatch.setenv("AGENTMETRY_URL", configured)
+    assert ingest._base_url() == ingest._DEFAULT_BASE_URL
+    # It must say so. A silent downgrade is the failure mode this project exists
+    # to make impossible: the operator believes they are forwarding somewhere
+    # they are not.
+    assert "unsupported scheme" in capsys.readouterr().err
+
+
+def test_trailing_slash_is_stripped_so_paths_do_not_double(monkeypatch):
+    monkeypatch.setenv("AGENTMETRY_URL", "http://127.0.0.1:8000/")
+    assert ingest._base_url() == "http://127.0.0.1:8000"
+
+
+def test_default_is_loopback_when_nothing_is_configured(monkeypatch):
+    monkeypatch.delenv("AGENTMETRY_URL", raising=False)
+    monkeypatch.delenv("AGENTMETRY_AUDIT_INGEST_URL", raising=False)
+    assert ingest._base_url() == "http://127.0.0.1:8000"


### PR DESCRIPTION
Closes the four gaps from the day-50 audit. A tool that inspects other people's supply chains ran no security linter, no static analysis and no dependency scanning over its own; gitleaks covered committed secrets and nothing else.

## ruff gains `S` (bandit) and `B` (bugbear)

`B` was already clean. `S` reported **1,698**, of which 1,654 were asserts in tests. That leaves 44 real ones. Five were genuine and are **fixed**, not suppressed. The rest are argued in place.

### The five: `try`/`except`/`pass`

In a recorder, a swallowed exception is an event that never existed and left no trace of not existing, which is the exact failure the README warns readers about. Four now log at debug. The fifth (`sys.stdout.reconfigure` before logging is configured) carries a `noqa` explaining that a log line about a console that cannot render UTF-8 would not render either.

One of the four mattered more than the rest:

```python
configured = str(getattr(settings, "anchor_log_path", "") or "").strip()
```

Falling back in silence meant `verify` compared the trail against a log sitting **beside** the trail, which an attacker who rewrote one could rewrite as well. The operator configured an external anchor precisely to avoid that and would never have learned the setting was not read.

### S310 got a fix, not a suppression

`AGENTMETRY_URL` reached `urlopen` unvalidated, so `file:///etc/passwd` would have turned every ingest POST into a local file read reported back through the hook. Reaching that needs code execution as the operator already, so this is hardening rather than a patched vulnerability, but the recorder should not be the component that widens what an attacker already inside can touch.

The scheme is now pinned to http/https, and an unusable one falls back to loopback **loudly**, because a silent downgrade is the failure this project exists to make impossible. Nine tests cover it.

### The rest, with reasoning next to each

| Rule | Count | Why it stays |
|---|---|---|
| `S105`/`S106` | 7 | Variable names containing "TOKEN" holding path placeholders (`{PYTHON}`) and an event topic (`llm/token`) |
| `S104` | 5 | Compare against `0.0.0.0` to avoid printing it as a clickable link, which is the opposite of binding it |
| `S608` | 3 | The f-strings interpolate only clause fragments built in the same function; every caller value goes through a bound parameter. `focus` raises on anything outside a closed set |
| `S603`/`S607` | 17 | Disabled project-wide with the argument in `pyproject.toml`: this project spawns `schtasks`, `python` and `powershell` by design, with argument lists and no shell |
| `S101` | 1,654 | `tests/**` only. An assert in production code still fails the build |

## CodeQL, pip-audit, Dependabot

- **CodeQL** `security-extended` over Python and TypeScript, on push, PR, and weekly so a newly published query finds old code.
- **`pip-audit --strict`** over the resolved tree. Verified locally: **clean**. CI upgrades pip first, since a runner's bundled pip is routinely behind an advisory and would otherwise dominate the finding list.
- **Dependabot** weekly for pip, npm and **GitHub Actions**. Actions are included deliberately: a pinned action is a dependency with code execution in a job holding an OIDC token good enough to publish to PyPI. Grouped, because a solo maintainer who opens Monday to eleven bot PRs stops reading them, and a queue nobody reads is worse than none because it looks like coverage.

CodeQL and `pip-audit` are **deliberately not required status checks**. Both report on the world rather than on the diff, so a CVE published overnight would block an unrelated docs fix. The `ci.yml` comment that mirrors branch protection now says so.

## SECURITY.md

Gains a table of what runs and where, plus what is still missing, stated plainly: no third-party pen test, no SOC 2, no signed release artifact, no reproducible build, unsigned MSI.

## Checks

- `ruff check agentmetry tests` with S and B enabled: **All checks passed**
- `pytest -q`: **1077 passed** (1068 plus nine new scheme tests)
- `agentmetry benchmark`: 26/26, zero missed, zero false positives
- All three YAML files parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)
