### PR TITLE
docs(readme): correct the attribution paragraph, which overstated the weakness

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,16 +455,33 @@ with optional external anchoring for threat models that include the host itself.
 The chain covers JSONL lines written after chaining was enabled, and it protects
 the JSONL, not the SQLite index the dashboard reads.
 
-**Tamper-evident is not attributable.** Ingest authenticates with one shared key,
-so any host holding it can post events claiming any `host_id`, any `fleet_id`, and
-any user identity. The chain proves ordering and non-modification of what was
-written; it does not prove who wrote it. For one developer recording their own
-machine that is a fair trade and the default. Across a fleet it means the trail
-records claims rather than facts, and a claim is not evidence. Per-host
-cryptographic identity is not in the open-source core and is not planned for it;
-it is being built into Agentmetry Enterprise, where fleets and key management are
-the problem being solved. Nothing here is removed or degraded either way, and the
-shared-key path stays the single-machine default.
+**Tamper-evident is not attributable.** The chain proves ordering and
+non-modification of what was written. It does not prove who wrote it.
+
+Be precise about the shape of that, because an earlier version of this paragraph
+was not. It said a key holder could post events "claiming any `host_id`, any
+`fleet_id`, and any user identity", which is not what the code does and made the
+weakness sound like identity spoofing. Ingest takes no identity from the caller:
+`ExternalIngestBody` in `agentmetry/api/routes/audit.py` has no `host_id` or
+`fleet_id` field, and `agentmetry/core/audit/identity.py` stamps every canonical
+event with the *receiving* orchestrator's own hostname plus its configured
+`fleet_id`. A client cannot claim to be another machine.
+
+What one shared key does buy an attacker is **injection**. Anyone holding
+`AGENTMETRY_API_KEY` can post to that orchestrator, and the events arrive stamped
+as native to the machine that accepted them, indistinguishable from real ones. A
+second consequence follows from the same design: point several hosts at one
+central orchestrator and every event carries that orchestrator's `host_id`, so
+per-host attribution is absent by construction rather than forgeable.
+
+For one developer recording their own machine both are a fair trade, and it is
+the default. Across a fleet it means the trail records what a machine *accepted*
+rather than what a machine *did*, and an auditor should hear that from you rather
+than find it. Per-host cryptographic identity is not in the open-source core and
+is not planned for it; it is being built into Agentmetry Enterprise as Ed25519
+host keypairs held in the OS keystore with per-post signatures, where fleets, key
+rotation and revocation are the problem being solved. Nothing here is removed or
+degraded either way, and the shared-key path stays the single-machine default.
 
 Read on its own, the chain catches corruption, truncation and in-place edits. It
 does not catch an attacker with write access to the data directory: they can edit

--- a/apps/orchestrator/tests/test_readme_claims.py
+++ b/apps/orchestrator/tests/test_readme_claims.py
@@ -126,3 +126,56 @@ def test_readme_documents_every_cli_command():
     assert not undocumented, (
         f"CLI commands missing from the README CLI Reference: {undocumented}"
     )
+
+
+# ----------------------------------------------------------------------
+# The attribution paragraph
+#
+# The README used to say a shared-key holder could post events "claiming any
+# host_id, any fleet_id, and any user identity". That was never what the code
+# did, and the overstatement travelled: three separate external audits repeated
+# it back as the project's fatal flaw. Overstating a weakness costs the same
+# credibility as overstating a strength, and it is harder to notice because it
+# sounds like honesty.
+#
+# The corrected paragraph makes a claim about the code, so the code checks it.
+# ----------------------------------------------------------------------
+
+
+def test_ingest_body_takes_no_identity_from_the_caller():
+    """The README says a client cannot claim to be another machine."""
+    from agentmetry.api.routes.audit import ExternalIngestBody
+
+    fields = set(ExternalIngestBody.model_fields)
+    assert "host_id" not in fields
+    assert "fleet_id" not in fields
+    # Nothing user-shaped either. If an identity field is ever added to this
+    # body, the README paragraph becomes false in the direction that matters.
+    assert not [f for f in fields if "user" in f or "operator" in f], sorted(fields)
+
+
+def test_identity_is_stamped_from_the_receiving_host():
+    from agentmetry.core.audit.identity import identity_fields
+
+    fields = identity_fields()
+    assert "host_id" in fields and fields["host_id"], fields
+    # fleet_id is omitted rather than emitted empty, so only assert the shape.
+    assert set(fields) <= {"host_id", "fleet_id"}, fields
+
+
+def test_readme_does_not_reintroduce_the_overstatement():
+    """Guards the correction itself, not just the code behind it.
+
+    The old sentence is quoted inside the corrected paragraph on purpose, so
+    this checks it never appears as an assertion again: once as a quotation is
+    expected, twice means somebody pasted the old text back.
+    """
+    text = _readme()
+    assert text.count("claiming any `host_id`") <= 1, (
+        "the overstated attribution claim appears more than once; the paragraph "
+        "quotes it exactly once while correcting it"
+    )
+    # The correction names the two files a reader can check. If either rename
+    # happens without updating the README, the invitation stops working.
+    assert "agentmetry/api/routes/audit.py" in text
+    assert "agentmetry/core/audit/identity.py" in text


### PR DESCRIPTION
The README said a shared-key holder could post events *"claiming any `host_id`, any `fleet_id`, and any user identity"*.

**That is not what the code does.**

```
$ python -c "from agentmetry.api.routes.audit import ExternalIngestBody; ..."
host_id in body: False
fleet_id in body: False
```

`ExternalIngestBody` has no identity field and never has. `core/audit/identity.py` stamps every canonical event with the **receiving** orchestrator's own hostname plus its configured `fleet_id`. A client cannot claim to be another machine.

## Why this mattered enough to fix

Three separate external audits read that sentence and reported identity spoofing as the project's biggest technical blocker. One called it *"The Fatal Flaw (Identity)"* and built a multi-week phase around fixing it.

Overstating a weakness costs the same credibility as overstating a strength, and it is harder to catch because it sounds like the honesty this project trades on. The corrected version is also the stronger one, because a reader can open two named files and confirm it in a minute.

This was already known privately. The enterprise `auth.py` docstring works through the same reading:

> #33 states that a shared-key holder "can post events claiming any host_id, any fleet_id, and any user identity". Reading the code, that is not so, and the truth is worth stating precisely because it changes where the fix belongs.

Issue #33 was closed on that basis and the paragraph it produced stayed live in the public README.

## What the paragraph says now

The real limit, which is still a real limit:

- **Injection.** Anyone holding `AGENTMETRY_API_KEY` can post to that orchestrator, and the events arrive stamped as native to the machine that accepted them, indistinguishable from real ones.
- **Attribution collapse**, which was not written down anywhere public before: point several hosts at one central orchestrator and every event carries that orchestrator's `host_id`, so per-host attribution is absent *by construction* rather than forgeable.
- Across a fleet the trail records what a machine **accepted** rather than what a machine **did**.

It also now names the Enterprise design concretely (Ed25519 host keypairs in the OS keystore, per-post signatures) instead of gesturing at it.

## Tests

The paragraph now makes a claim about the code, so the code checks it. Three tests in `test_readme_claims.py`:

- `test_ingest_body_takes_no_identity_from_the_caller` — fails if an identity field is ever added to the ingest body, which is exactly when the README would become false
- `test_identity_is_stamped_from_the_receiving_host`
- `test_readme_does_not_reintroduce_the_overstatement` — the old sentence is quoted once inside the correction on purpose, so this allows exactly one occurrence and fails on two. It also asserts both referenced file paths still exist in the text

## Scope

README only. The site's four versions of this caveat (`/security`, `/pilot`, the homepage, the MCP tool description) all describe the **write-access-to-the-file** threat, which is accurate and a different claim. None of them repeat the overstatement.

`/pilot` says a fleet trail *"records claims about which host sent an event rather than proof"*, which is defensible for the central-orchestrator case and is marketing copy rather than a code claim, so I left it. Worth a second look if you want the two to read identically.

- `ruff check` clean
- 1116 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
