### PR TITLE
fix(security): sanitize the last two log arguments, closing code scanning

### DIFF
--- a/apps/orchestrator/agentmetry/core/audit/detection/disposition.py
+++ b/apps/orchestrator/agentmetry/core/audit/detection/disposition.py
@@ -579,13 +579,15 @@ async def apply_disposition(
         except Exception:
             logger.exception("Failed to forward disposition for %s", _loggable(rule_id))
 
-    # `previous` and `normalized` are validated against STATUSES above, so both
-    # are already closed-set values. The other two are not.
+    # `previous` and `normalized` are validated against STATUSES before they get
+    # here, so passing them raw was safe and CodeQL kept flagging them anyway.
+    # Sanitizing a closed-set value is a no-op, and a no-op costs less than a
+    # dismissal somebody has to re-justify every time the tab is read.
     logger.info(
         "DISPOSITION %s %s -> %s by %s",
         _loggable(rule_id),
-        previous,
-        normalized,
+        _loggable(previous),
+        _loggable(normalized),
         _loggable(decided_by or "operator"),
     )
     return current


### PR DESCRIPTION
Takes open code scanning alerts from **7 to 0**.

`previous` and `normalized` are validated against `STATUSES` before reaching the log, so passing them raw was correct. CodeQL cannot see the validation and kept flagging both.

Sanitizing a closed-set value is a **no-op** (verified: every member of `STATUSES` round-trips through `_loggable` unchanged). That costs less than a dismissal somebody has to re-justify every time they read the tab, and less than a comment explaining why two alerts are fine.

- 1120 tests, ruff clean
- No behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)