### PR TITLE
ci: move both artifact actions together, and say what stays untested

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,10 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/upload-artifact@v4
+      # Bumped in step with download-artifact below. These two are one handoff
+      # and moving one without the other leaves the halves majors apart, which
+      # is what Dependabot proposed and why that PR was closed.
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: apps/orchestrator/dist/
@@ -131,7 +134,16 @@ jobs:
       # it the publish step fails with an unhelpful authentication error.
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      # v8 errors on a digest mismatch rather than warning, checks Content-Type
+      # before unzipping, and downloads by name rather than by id, so the v5
+      # breaking change about download-by-id does not apply here.
+      #
+      # Read this before the next release: `publish` is tag-gated, so neither CI
+      # nor the workflow_dispatch dry run ever runs this step. A green run on the
+      # PR that changed it proves nothing about it. The first real exercise is
+      # the next `git tag v*`, and if it fails it fails after verify and build
+      # have already passed, with the tag already pushed.
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
Replaces [#62](https://github.com/blitzcrieg1/agentmetry/pull/62), which is closed.

## Why not just merge #62

It bumped `download-artifact` v4 → v8 **on its own**. `upload-artifact` is at v7 and Dependabot did not propose it, so merging that PR alone would have left the two halves of a single handoff four majors apart, in the job that publishes to PyPI.

```
build:    actions/upload-artifact@v4   -> v7
publish:  actions/download-artifact@v4 -> v8
```

## What v8 actually changes

Read rather than assumed:

- **ESM migration** — explicitly transparent to callers
- **Content-Type checked before unzipping**, to support direct uploads
- **Digest mismatches now error** instead of warning. A security improvement; a legitimate artifact matches
- v7 requires **runner ≥ 2.327.1** — GitHub-hosted runners exceed this
- The v5 breaking change is about downloading **by id**. This downloads **by name**

Nothing there requires matching majors. Matching them removes the question.

## The part that matters, and it is now a comment in the file

**`publish` is tag-gated.** Neither CI nor the `workflow_dispatch` dry run ever runs `download-artifact`. A green check on this PR says nothing about the step it changes.

The first real exercise is the next `git tag v*` — after `verify` and `build` have already passed, with the tag pushed. That is a bad moment to discover a problem, so it is written next to the step rather than left in a PR description nobody re-reads.

## What the dry run did prove

Ran `release.yml` via `workflow_dispatch` against this branch:

```
verify           success
build            success
publish to PyPI  skipped
```

Inside `build`, `Run actions/upload-artifact@v7` → **success**. So the upload half is tested. The download half is not, and cannot be without spending a version number.

## Recommendation

Merge. The alternative is staying on v4 indefinitely, which is worse: the v4 line is four majors behind and the same untestability applies to any future bump. If the next release fails at `publish`, the fix is a one-line revert and a re-run of the tag, which is recoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
