### PR TITLE
docs(splunk): fix disposition join key to correlation_id::rule_id

### DIFF
--- a/docs/integrations/fleet-via-siem.md
+++ b/docs/integrations/fleet-via-siem.md
@@ -91,9 +91,9 @@ anyone acted, so this count is the real health metric for the deployment.
 
 ```
 index=agentmetry action.type=detection
-| eval key=correlation_id.":".'detection.rule_id'
+| eval key=correlation_id."::".'detection.rule_id'
 | search NOT [ search index=agentmetry action.type=detection_disposition
-               | eval key=correlation_id.":".'disposition.rule_id' | fields key ]
+               | eval key=correlation_id."::".'disposition.rule_id' | fields key ]
 | stats count by host_id, detection.rule_id
 ```
 


### PR DESCRIPTION
## Summary
- Fix untriaged-detection join in `fleet-via-siem.md` from single colon to double colon

## Why
`disposition.py` uses `correlation_id::rule_id` as `detection_key`. A single-colon join silently misses every closure, so SOC searches never drop triaged findings.

Matches enterprise TA saved search **Untriaged critical or high** in agentmetry-enterprise PR #9.

## Test plan
- [x] Doc-only change; join key matches `docs/integrations/sigma/agentmetry_critical_detection_untriaged.yml` comments