### PR TITLE
chore: put the Sponsor button on the repository

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# Puts the Sponsor button on the repository page. Enabling GitHub Sponsors on
+# the account does not do this on its own: the button only appears when a repo
+# carries this file.
+github: blitzcrieg1


### PR DESCRIPTION
GitHub Sponsors was enabled on the account this morning. The repository still showed no Sponsor button, because those are two separate steps and only one had been done: the button appears when a repo carries `.github/FUNDING.yml`, and this one did not.

Four funding applications went out today. The page a reader is most likely to land on after any of them is this one, and until now it gave them no way to fund the work.

`github.com/sponsors/blitzcrieg1` returns 200, so the link resolves rather than pointing at a profile that does not exist yet.

The file carries a comment saying why it exists, since "enabling Sponsors is not enough on its own" is exactly the kind of thing that gets rediscovered a year later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)