### PR TITLE
release: 0.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,18 +161,26 @@ jobs:
       - name: Audit dependencies
         run: |
           python -m pip install --upgrade pip-audit
-          # `--skip-editable` drops Agentmetry itself, which the step above
-          # installed with `pip install -e`. Auditing our own package against
-          # PyPI asks whether the version we are about to publish is already
-          # published, and under `--strict` the honest answer "no" is a
-          # failure. That made every version bump red: 0.6.0 failed with
-          # "Dependency not found on PyPI and could not be audited", which
-          # reads like a supply-chain finding and is a release blocking itself.
+          # Audit the dependency set, not the environment.
           #
-          # `--strict` stays. Failing on a dependency that cannot be audited is
-          # the whole point; the exclusion is only for the one package whose
-          # source is this checkout.
-          pip-audit --progress-spinner off --strict --skip-editable
+          # Auditing the environment includes Agentmetry itself, installed
+          # editable by the step above, and asks PyPI whether the version we
+          # are about to publish is already published. Under `--strict` the
+          # honest answer "no" is a build failure, so every version bump went
+          # red: 0.6.0 failed with "Dependency not found on PyPI and could not
+          # be audited", which reads like a supply-chain finding and is really
+          # a release blocking itself.
+          #
+          # `--skip-editable` does not help. It excludes the package and then
+          # `--strict` fails precisely because something was excluded
+          # ("distribution marked as editable"). The two flags cannot both hold.
+          #
+          # `pip freeze --exclude-editable` is the dependency set with our own
+          # package removed, which is the thing we actually wanted to ask about.
+          # `--strict` stays, because failing on a dependency that cannot be
+          # audited is the reason this job exists.
+          pip freeze --exclude-editable > /tmp/deps.txt
+          pip-audit --progress-spinner off --strict -r /tmp/deps.txt
 
   dashboard:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,18 @@ jobs:
       - name: Audit dependencies
         run: |
           python -m pip install --upgrade pip-audit
-          pip-audit --progress-spinner off --strict
+          # `--skip-editable` drops Agentmetry itself, which the step above
+          # installed with `pip install -e`. Auditing our own package against
+          # PyPI asks whether the version we are about to publish is already
+          # published, and under `--strict` the honest answer "no" is a
+          # failure. That made every version bump red: 0.6.0 failed with
+          # "Dependency not found on PyPI and could not be audited", which
+          # reads like a supply-chain finding and is a release blocking itself.
+          #
+          # `--strict` stays. Failing on a dependency that cannot be audited is
+          # the whole point; the exclusion is only for the one package whose
+          # source is this checkout.
+          pip-audit --progress-spinner off --strict --skip-editable
 
   dashboard:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ separately (currently `1.2.0`) and changes additively.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-24
+
+Most of this release came from strangers. The MCP schema work was posted to
+r/mcp for review, six people took the design apart, and seven issues were filed
+against this project as a result. Three of them are fixed below.
+
 ### Added
 
 - **The fifteen sequence detections ship as Sigma rules.** The Sigma pack
@@ -47,6 +53,92 @@ separately (currently `1.2.0`) and changes additively.
   That table is checked against `BUILTIN_RULE_IDS` rather than trusted: a
   sixteenth rule with neither a corpus case nor an entry fails the script instead
   of silently shipping a pack that claims more than it has.
+
+- **The initialize handshake is recorded, so a release can be told from a rug
+  pull.** `serverInfo.version` and `capabilities.tools.listChanged` cross the
+  wire on every MCP session and were being discarded. Both are now attached to
+  the schema fingerprint event.
+
+  The digest moving is ambiguous on its own. Digest moved and server version
+  moved usually means somebody shipped a release. Digest moved and version
+  identical is the shape worth looking at first. The Sigma rule previously told
+  an analyst to go and read a changelog; the version string is the handle that
+  makes that check something a machine can do.
+
+  Said plainly in the code and repeated here: the version is attacker
+  controlled. It separates ordinary churn from suspicious churn and it is not a
+  security boundary. `listChanged` is captured for the inverse case, a server
+  that promised to send `notifications/tools/list_changed`, changed its list,
+  and stayed silent.
+
+- **A schema move now names the tool that moved.** Each tool gets its own digest
+  alongside the whole-listing digest, so an alert can say which tool changed
+  rather than only which server. Tools added and removed come through as counts.
+
+  The obvious way to answer "why did this fire" is to store the listing itself.
+  That would mean writing a poisoned tool description into the trail and then
+  forwarding it to a SIEM, which is storing the payload. So the answer is a hash
+  per tool instead: enough to point at one tool and reach for an inspector,
+  never enough to carry the attack. The id is a hash of the tool name for the
+  same reason server names are hashed, since a tool called
+  `internal-payroll-export` is itself information.
+
+  Requested by the first external tester to run the sensor, and shipped inside
+  the week he agreed to test it. Closes
+  [#120](https://github.com/blitzcrieg1/agentmetry/issues/120).
+
+### Fixed
+
+- **A failed `tools/list` is no longer silent, and an empty one no longer
+  poisons the baseline.** Two false-positive roads, both closing
+  [#106](https://github.com/blitzcrieg1/agentmetry/issues/106).
+
+  A listing that errors partway already had its accumulated pages dropped, which
+  stopped a retry hashing to a fingerprint no server ever served. But nothing was
+  recorded, and silence is not the same as unknown: an operator reading a quiet
+  week could not tell a server that never moved from one nobody managed to read.
+  A failed listing now emits an explicit `unavailable` event and leaves the
+  stored baseline exactly where it was.
+
+  The second road arrives through a success. A registry that intermittently
+  answers with no tools, or a server listed before it finished starting, wrote an
+  empty baseline. The next healthy listing then differed from it and was reported
+  as a change, which labels a server coming up correctly as a rug pull. Growing
+  out of an empty baseline is now a first sighting. Deliberately one way: going
+  from a populated listing to an empty one is still a change, because tools
+  actually disappearing is the thing this watches for.
+
+- **Splunk disposition searches joined on the wrong key.** The saved searches
+  matched dispositions to detections by `correlation_id` alone, so a session with
+  two findings had one disposition close both. The join is now
+  `correlation_id::rule_id`.
+
+- **Seven CodeQL findings, and the log sanitizer rewritten so CodeQL can follow
+  it.** The first fix used `encode("unicode_escape")`, which is correct and which
+  static analysis could not trace through, leaving the alerts open. Replaced with
+  an explicit chain of `.replace()` calls.
+
+### Changed
+
+- **Dashboard on Next 16, React 19, with eslint 9 flat config.** Driven by
+  dependency advisories rather than by any feature. `next lint` was removed in
+  Next 16 and fails with a message about an invalid project directory, which
+  reads like a broken path rather than a deleted command, so `package.json` now
+  calls eslint directly. Twelve `react-hooks/set-state-in-effect` sites are
+  downgraded to warnings and tracked in
+  [#95](https://github.com/blitzcrieg1/agentmetry/issues/95) rather than
+  refactored inside a framework migration.
+
+- **`README.md` states what the MCP fingerprint does not prove.** A reviewer
+  pointed out that a quiet digest reads as a claim that the server is safe. It is
+  a tripwire. A server can hold its listing identical and change what a tool does
+  at call time, and that is now written down instead of implied.
+
+- **The attribution paragraph in `README.md` was corrected, having overstated the
+  weakness.** It claimed a key holder could post events asserting any `host_id`,
+  `fleet_id` and user identity. The ingest body has no identity fields and they
+  are stamped by the receiving host. Four separate reviews repeated the error
+  back before anyone checked the code. Three tests now pin the behaviour.
 
 ## [0.5.0] - 2026-08-21
 

--- a/apps/orchestrator/agentmetry/core/version.py
+++ b/apps/orchestrator/agentmetry/core/version.py
@@ -10,4 +10,4 @@ Bump this here and add the matching CHANGELOG section in the same commit.
 
 from __future__ import annotations
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"


### PR DESCRIPTION
PyPI still serves **0.5.0** while master is **72 commits ahead**. That gap was about to cost something concrete: the first external tester agreed to run the sensor for a week, and `pip install agentmetry` would have handed him code from before every one of the three things he asked about.

## What is in it

Most of this release came from strangers. The MCP schema work was posted to r/mcp for review, six people took the design apart, and seven issues were filed against this project as a result. Three are fixed here.

**The initialize handshake is recorded** (#108). `serverInfo.version` and `capabilities.tools.listChanged` were crossing the wire every session and being discarded. Digest moved plus version moved usually means a release. Digest moved plus version identical is the shape worth investigating first. The version is attacker-controlled, which is stated in the code and in the changelog: it separates ordinary churn from suspicious churn and is not a security boundary.

**A schema move names the tool that moved** (#120). Per-tool digests alongside the listing digest. The obvious way to answer "why did this fire" is to store the listing, which means writing a poisoned description into the trail and forwarding it to a SIEM. A hash per tool answers the question without carrying the payload. Requested by the external tester yesterday, shipping inside his test week.

**A failed `tools/list` is no longer silent, and an empty one no longer poisons the baseline** (#106). Two separate false-positive roads. Dropping the pages already stopped a bad fingerprint, but recorded nothing, and silence is not the same as unknown. Separately, a registry that intermittently lists empty was writing an empty baseline, so the next healthy listing read as a rug pull.

Also: the Sigma sequence pack, the Splunk disposition join key, seven CodeQL findings, and Next 16 on the dashboard.

## Release mechanics

`core/version.py` is 0.6.0 and the newest CHANGELOG section matches, which `tests/test_version.py` pins. The release workflow refuses to publish if the tag and the packaged version disagree.

After merge, tag `v0.6.0` on master to trigger Trusted Publishing.

1140 tests pass, ruff clean, ruleset fingerprint unchanged at `56ad3de1ad8533cf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)