### PR TITLE
fix(ingest): stop pydantic dropping the 0.6.0 MCP fields

### DIFF
--- a/apps/orchestrator/agentmetry/api/routes/audit.py
+++ b/apps/orchestrator/agentmetry/api/routes/audit.py
@@ -8,7 +8,7 @@ from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from agentmetry.core.auth import require_api_key
 from agentmetry.core.audit.detection.disposition import STATUSES, get_disposition_store
@@ -42,8 +42,48 @@ class IngestToolBody(BaseModel):
     mitre: dict[str, str] | None = None
 
 
+#: Actor kinds a capture surface may assert. Anything else is coerced to
+#: `agent`, which is the safe direction: never silently promoted to `human`
+#: (whose approvals reset detection gates) and never to `autonomous` (which
+#: `autonomous-unapproved-write` keys on). A surface that needs a new kind adds
+#: it here deliberately rather than by sending a novel string.
+_ACTOR_TYPES = frozenset({"human", "agent", "autonomous", "system"})
+
+
+class IngestInitiatorBody(BaseModel):
+    """Who triggered this call, as the capture surface saw it.
+
+    This is not identity. `identity_fields()` stamps `host_id` and `fleet_id` on
+    the receiving orchestrator whatever a client sends, and that lockdown is
+    unchanged here: this field says what *kind* of actor acted, never which
+    machine it was. `external.py` already reads and honours it; without the
+    field declared, pydantic dropped it before that code ever saw it.
+    """
+
+    actor_type: str = "human"
+    trigger: str = "manual"
+    operator_id: str = ""
+
+    @field_validator("actor_type")
+    @classmethod
+    def _known_actor(cls, v: str) -> str:
+        return v if v in _ACTOR_TYPES else "agent"
+
+
 class ExternalIngestBody(BaseModel):
-    """Adapter payload — normalized to canonical v1.1 on ingest."""
+    """Adapter payload — normalized to canonical v1.2 on ingest.
+
+    Every field a capture surface sends must be declared here. Pydantic ignores
+    what it does not know, silently, so an undeclared field is not an error at
+    ingest: it is a feature that works in unit tests and disappears over HTTP.
+
+    That has now happened twice. `traits` and `mitre` were dropped, which made
+    hashed-only events invisible to every command rule. Then 0.6.0 shipped MCP
+    per-tool digests and the initialize handshake, and those were dropped too,
+    so the release headline did not survive the wire. `test_ingest_roundtrip.py`
+    exists so there is not a third time: it builds real proxy payloads and fails
+    if any key does not survive this model.
+    """
 
     source_app: str = Field(
         ...,
@@ -71,10 +111,19 @@ class ExternalIngestBody(BaseModel):
     # pydantic drops it and a `log`-mode match is silently lost.
     dlp: dict[str, Any] | None = None
     tool_policy: dict[str, Any] | None = None
+    # Who the capture surface says triggered this. Honoured by external.py.
+    initiator: IngestInitiatorBody | None = None
     # Compact `tools/list` fingerprint from mcp_audit_proxy. Hash only: the
     # description never leaves the proxy process.
     schema_fingerprint: str = ""
     schema_tool_count: int = 0
+    # 0.6.0 MCP fields. Per-tool digests so a schema move names the tool that
+    # moved rather than only the server, and the two initialize handshake
+    # fields that separate a shipped release from a rug pull. All hashes and
+    # flags: no tool name, no description, nothing model-visible.
+    schema_tool_digests: dict[str, str] = Field(default_factory=dict)
+    server_version: str = ""
+    list_changed: bool | None = None
 
 
 def _parse_event_ts(event: dict[str, Any]) -> datetime | None:

--- a/apps/orchestrator/tests/test_ingest_roundtrip.py
+++ b/apps/orchestrator/tests/test_ingest_roundtrip.py
@@ -1,0 +1,163 @@
+"""Every field a capture surface sends must survive `ExternalIngestBody`.
+
+Pydantic ignores unknown keys, silently. So an undeclared field is not an error
+at ingest time. It is a feature that passes its unit tests, because those call
+the ingest functions with a dict, and then vanishes at the HTTP boundary where
+the real capture path lives.
+
+This has happened twice.
+
+`tool.traits` and `tool.mitre` were dropped first. The hook computes both from
+the plaintext command before hashing it away, so dropping them made every
+default-config event invisible to every command-based sequence rule. The rules
+passed their tests, because the tests injected a `command` field that production
+events did not have.
+
+Then 0.6.0 shipped MCP per-tool digests and the initialize handshake, and
+`schema_tool_digests`, `server_version`, `list_changed` and `initiator` were all
+dropped the same way. The release headline, "a schema move names the tool that
+moved", was true in the module and false over the wire.
+
+Both bugs are the same bug. These tests build payloads with the real proxy
+builders rather than hand-written dicts, so a field added to a builder without
+being added to the model fails here instead of shipping.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from agentmetry.api.routes.audit import ExternalIngestBody
+from agentmetry.core.diagnostics.mcp_schema import fingerprint_each_tool, fingerprint_tools
+
+_TOOLS_DIR = Path(__file__).resolve().parents[1] / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+
+def _proxy():
+    try:
+        import mcp_audit_proxy
+    except Exception as exc:  # pragma: no cover - import guard
+        pytest.skip(f"mcp_audit_proxy not importable: {exc}")
+    return mcp_audit_proxy
+
+
+def _survives(payload: dict) -> dict:
+    """What is left of a payload after the ingest model has parsed it."""
+    return ExternalIngestBody(**payload).model_dump(exclude_none=True)
+
+
+SAMPLE_TOOLS = [
+    {"name": "send_email", "description": "Send an email", "inputSchema": {"type": "object"}},
+    {"name": "list_templates", "description": "List templates"},
+]
+
+
+def test_every_key_the_schema_builder_emits_survives_ingest():
+    """The structural guard. Catches the next dropped field, whatever it is."""
+    proxy = _proxy()
+    payload = proxy.build_schema_payload(
+        "postmark",
+        SAMPLE_TOOLS,
+        "corr-1",
+        server_version="1.4.2",
+        list_changed=True,
+    )
+    kept = _survives(payload)
+    missing = sorted(k for k in payload if k not in kept)
+    assert not missing, (
+        f"mcp_audit_proxy sends {missing} and ExternalIngestBody drops them. "
+        "Declare the field on the model, or stop sending it."
+    )
+
+
+def test_every_key_the_call_builder_emits_survives_ingest():
+    proxy = _proxy()
+    payload = proxy.build_call_payload(
+        {"method": "tools/call", "params": {"name": "send_email", "arguments": {"to": "a@b.c"}}},
+        "postmark",
+        "corr-2",
+    )
+    assert payload is not None
+    kept = _survives(payload)
+    missing = sorted(k for k in payload if k not in kept)
+    assert not missing, (
+        f"mcp_audit_proxy sends {missing} and ExternalIngestBody drops them."
+    )
+
+
+def test_per_tool_digests_reach_the_other_side():
+    """The 0.6.0 headline, checked over the model rather than the module.
+
+    Without this the digests are computed, POSTed, and discarded, and a schema
+    move can only say which server changed.
+    """
+    payload = {
+        "source_app": "mcp_proxy",
+        "event_type": "mcp_schema",
+        "schema_fingerprint": fingerprint_tools(SAMPLE_TOOLS),
+        "schema_tool_count": len(SAMPLE_TOOLS),
+        "schema_tool_digests": fingerprint_each_tool(SAMPLE_TOOLS),
+        "server_version": "1.4.2",
+        "list_changed": True,
+    }
+    kept = _survives(payload)
+    assert kept["schema_tool_digests"] == payload["schema_tool_digests"]
+    assert kept["server_version"] == "1.4.2"
+    assert kept["list_changed"] is True
+
+
+def test_initiator_survives_and_reaches_the_canonical_event():
+    """`external.py` reads `payload["initiator"]`; the model used to hide it."""
+    from agentmetry.core.audit.external import build_external_canonical
+
+    payload = {
+        "source_app": "mcp_proxy",
+        "event_type": "tool_called",
+        "tool_qualified": "postmark.send_email",
+        "initiator": {"actor_type": "autonomous", "trigger": "cron", "operator_id": "svc"},
+    }
+    kept = _survives(payload)
+    assert kept["initiator"]["actor_type"] == "autonomous"
+    event = build_external_canonical(kept)
+    assert event["initiator"]["actor_type"] == "autonomous"
+    assert event["initiator"]["trigger"] == "cron"
+
+
+def test_unknown_actor_type_falls_back_to_agent():
+    """Coerced down, never up.
+
+    `human` resets approval gates and `autonomous` is what
+    `autonomous-unapproved-write` keys on, so an unrecognised string must not
+    land on either. A new surface adds its kind to `_ACTOR_TYPES` deliberately.
+    """
+    kept = _survives(
+        {
+            "source_app": "cursor",
+            "event_type": "tool_called",
+            "initiator": {"actor_type": "definitely-not-a-real-kind"},
+        }
+    )
+    assert kept["initiator"]["actor_type"] == "agent"
+
+
+def test_client_cannot_assert_identity():
+    """The lockdown that must not regress while opening `initiator`.
+
+    `host_id` and `fleet_id` are stamped by the receiving orchestrator. Adding
+    an actor field must not become a way to claim to be another machine.
+    """
+    kept = _survives(
+        {
+            "source_app": "cursor",
+            "event_type": "tool_called",
+            "host_id": "not-my-host",
+            "fleet_id": "not-my-fleet",
+        }
+    )
+    assert "host_id" not in kept
+    assert "fleet_id" not in kept


### PR DESCRIPTION
The 0.6.0 headline does not survive HTTP.

`ExternalIngestBody` declares `schema_fingerprint` and `schema_tool_count`. Pydantic ignores unknown keys **silently**, so everything else 0.6.0 added was POSTed by the proxy and thrown away at the ingest boundary:

```
schema_tool_digests    survives ingest: False
server_version         survives ingest: False
list_changed           survives ingest: False
initiator              survives ingest: False
```

So a schema move could only ever name the server, never the tool. The initialize handshake that separates a shipped release from a rug pull never reached the trail. And `external.py:66` has read `payload["initiator"]` the whole time, so the consuming code was already there; the model hid the field before it ran.

## Why the tests passed

They call `_ingest_observed_schema(payload)` with a dict and never cross the model. Unit tests of the function, not the transport.

Which is the same shape as the trait bug this repo already documents: tests that pass because they inject a field production events do not have.

## This is the second time in this file

`tool.traits` and `tool.mitre` were dropped exactly this way, and it made hashed-only events invisible to every command-based sequence rule. The comment explaining that sits four lines above the fields this PR adds.

So the fix is not four more fields. `tests/test_ingest_roundtrip.py` builds payloads with the **real proxy builders** and fails if any key does not survive the model. A field added to a builder without being added to the model now fails in CI rather than shipping.

## Opening `initiator` without reopening spoofing

`actor_type` is constrained to `{human, agent, autonomous, system}` and coerced **down** to `agent`, never up. `human` resets approval gates, and `autonomous` is what `autonomous-unapproved-write` keys on, so an unrecognised string must not land on either. A new surface adds its kind deliberately.

Identity is unchanged. `host_id` and `fleet_id` are still stamped by the receiving orchestrator, with a test pinning that a client cannot assert them.

## Not in scope

`autonomous-unapproved-write` still cannot fire on IDE capture, because the hook path emits `human`, `agent` and `system` and never `autonomous` (zero occurrences in ~32k trail events). That rule lives in frozen files and needs its own decision.

1146 tests pass, ruff clean, ruleset fingerprint unchanged at `56ad3de1ad8533cf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)