### PR TITLE
added 3 DLP rules

### DIFF
--- a/apps/orchestrator/agentmetry/policies/dlp/manifest.yaml
+++ b/apps/orchestrator/agentmetry/policies/dlp/manifest.yaml
@@ -159,3 +159,29 @@ rules:
     pattern: "(?i)\\b(ANTHROPIC_BASE_URL|ANTHROPIC_AUTH_TOKEN|OPENAI_BASE_URL|OPENAI_API_BASE|GEMINI_BASE_URL|MOONSHOT_API_KEY|DASHSCOPE_API_KEY|DEEPSEEK_API_KEY|ZHIPUAI_API_KEY|MINIMAX_API_KEY|QWEN_API_KEY|HTTP_PROXY|HTTPS_PROXY|NODE_OPTIONS|PYTHONSTARTUP|LD_PRELOAD)[\"']?\\s*[=:]"
     category: "execution_hijack"
     severity: "critical"
+
+  - id: "stripe_api_key"
+    name: "Stripe API Key"
+    description: "Detects Stripe live/test secret keys"
+    pattern: "(?i)\\bsk_(live|test)_[0-9a-z]{24,}\\b"
+    category: "credentials"
+    severity: "critical"
+
+  # Anthropic keys (sk-ant-api03-...) don't fit the generic sk-[a-zA-Z0-9]{20,}
+  # shape below: the hyphen after "ant" (and again after "api03") breaks the
+  # alnum-only run at 3 characters, so the generic rule never fires on them
+  # despite starting with the same "sk-" prefix. Needs its own rule, and a
+  # distinct rule id is more useful in a detection than a generic match anyway.
+  - id: "anthropic_api_key"
+    name: "Anthropic API Key"
+    description: "Detects Anthropic API keys (sk-ant-...)"
+    pattern: "(?i)\\bsk-ant-[a-zA-Z0-9_-]{20,}"
+    category: "credentials"
+    severity: "critical"
+
+  - id: "generic_provider_api_key"
+    name: "Generic LLM Provider API Key"
+    description: "Detects OpenAI-shaped provider API keys (sk-...); Anthropic and DashScope keys have their own rules above"
+    pattern: "(?i)\\bsk-[a-zA-Z0-9]{20,}\\b"
+    category: "credentials"
+    severity: "critical"

--- a/apps/orchestrator/tests/test_dlp_scanner.py
+++ b/apps/orchestrator/tests/test_dlp_scanner.py
@@ -67,6 +67,55 @@ def test_dlp_scan_dashscope_api_token():
     assert verdict.match.rule_id == "dashscope_api_token"
 
 
+def test_dlp_scan_stripe_live_key():
+    key = "sk_live_" + "a1b2c3d4e5f6g7h8i9j0k1l2"  # gitleaks:allow fake fixture, not a real Stripe key
+    args = {"command": f"curl -u {key}: https://api.stripe.com/v1/charges"}
+    verdict = scan("run_command", args)
+    assert verdict.matched is True
+    assert verdict.match.rule_id == "stripe_api_key"
+
+
+def test_dlp_scan_stripe_test_key():
+    key = "sk_test_" + "a1b2c3d4e5f6g7h8i9j0k1l2"  # gitleaks:allow fake fixture, not a real Stripe key
+    args = {"command": f"export STRIPE_SECRET_KEY={key}"}
+    verdict = scan("run_command", args)
+    assert verdict.matched is True
+    assert verdict.match.rule_id == "stripe_api_key"
+
+
+def test_dlp_scan_stripe_key_too_short_is_near_miss():
+    # Stripe-shaped prefix, but the token body is well under the 24-char floor —
+    # must not fire, or every "sk_live_" mention in a comment/docstring would.
+    key = "sk_live_abc123"  # gitleaks:allow fake fixture, deliberately too short
+    args = {"command": f"echo {key}"}
+    verdict = scan("run_command", args)
+    assert verdict.matched is False
+
+
+def test_dlp_scan_anthropic_api_key():
+    key = "sk-ant-api03-" + "a1B2c3D4e5F6g7H8i9J0k1L2"  # gitleaks:allow fake fixture, not a real Anthropic key
+    args = {"command": f"export ANTHROPIC_API_KEY={key}"}
+    verdict = scan("run_command", args)
+    assert verdict.matched is True
+    assert verdict.match.rule_id == "anthropic_api_key"
+
+
+def test_dlp_scan_generic_provider_api_key():
+    key = "sk-" + "a1B2c3D4e5F6g7H8i9J0k1L2"  # gitleaks:allow fake fixture, not a real OpenAI key
+    args = {"command": f"export OPENAI_API_KEY={key}"}
+    verdict = scan("run_command", args)
+    assert verdict.matched is True
+    assert verdict.match.rule_id == "generic_provider_api_key"
+
+
+def test_dlp_scan_generic_key_short_word_is_near_miss():
+    # "sk-" followed by a short ordinary word, not a 20+ char token — must not
+    # fire, or any mention of e.g. "sk-test" in a log line becomes a critical finding.
+    args = {"command": "echo sk-test"}  # gitleaks:allow fake fixture, deliberately too short
+    verdict = scan("run_command", args)
+    assert verdict.matched is False
+
+
 def test_dlp_scan_safe_args():
     args = {"command": "ls -la"}
     verdict = scan("run_command", args)


### PR DESCRIPTION
Added three DLP rules to [manifest.yaml] all credentials / critical:

stripe_api_key — (?i)\bsk_(live|test)_[0-9a-z]{24,}\b, exactly as the issue specified.
anthropic_api_key — a separate rule (per the assignee's stated preference), (?i)\bsk-ant-[a-zA-Z0-9_-]{20,}, since the generic pattern's alnum-only run breaks at the hyphen after ant and never matches Anthropic keys.
generic_provider_api_key — (?i)\bsk-[a-zA-Z0-9]{20,}\b for OpenAI-shaped keys.

Added 6 test cases, a fire test each for Stripe live, Stripe test, Anthropic, and generic-provider, plus the two near-misses requested (a too-short Stripe-shaped string, and sk- followed by a short word like sk-test), etc.

All test cases successful. Closes #4 

