### PR TITLE
docs: credit the second external contributor

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,13 +12,21 @@ without rewriting history.
 
 ## External contributors
 
-**[@jeetsingh008](https://github.com/jeetsingh008)**, 1 commit.
-[`e9a1b9c`](https://github.com/blitzcrieg1/agentmetry/commit/e9a1b9c) on
-2026-07-29: a neutral Windows path in an ingest client test fixture ([#30]).
+**[@hvadlamani1](https://github.com/hvadlamani1)** ([#126]), 2026-08-27: three
+DLP rules for Stripe, Anthropic and generic provider API keys, with six tests.
 
-That is the complete list, and it is short on purpose rather than by omission.
-This is a single-maintainer project with one outside code contribution, and
-saying so is more useful than a page that implies a community.
+Three of those tests are near-misses: `sk_live_abc123` and `echo sk-test` have
+to stay *silent*, because a rule that fires on every mention of a key prefix in
+a comment is worse than no rule. Writing the near-miss without being asked is
+the thing this project cares most about in a detection contribution.
+
+**[@jeetsingh008](https://github.com/jeetsingh008)** ([#30]), 2026-07-29:
+[`e9a1b9c`](https://github.com/blitzcrieg1/agentmetry/commit/e9a1b9c), a neutral
+Windows path in an ingest client test fixture.
+
+That is the complete list. It is short, and it is listed by name rather than
+summarised, because two outside contributions on a single-maintainer project
+are two more than none and both are easier to lose than to add.
 
 ```bash
 git shortlog -sne --all
@@ -67,6 +75,7 @@ confirms it works. Four such reports arrived from strangers on r/mcp in August
 shipped in 0.6.0 and 0.7.0. That is the highest-value thing anyone can send.
 
 [#30]: https://github.com/blitzcrieg1/agentmetry/pull/30
+[#126]: https://github.com/blitzcrieg1/agentmetry/pull/126
 [#103]: https://github.com/blitzcrieg1/agentmetry/issues/103
 [#106]: https://github.com/blitzcrieg1/agentmetry/issues/106
 [#111]: https://github.com/blitzcrieg1/agentmetry/issues/111


### PR DESCRIPTION
`CONTRIBUTORS.md` said there had been exactly one outside code contribution and called it "the complete list". True when written this morning, false by the afternoon: [#126](https://github.com/blitzcrieg1/agentmetry/pull/126) landed three DLP rules from @hvadlamani1.

Their entry says what the contribution actually did, including the part a reviewer skimming the diff would miss: **three of its six tests are near-misses.** `sk_live_abc123` and `echo sk-test` both have to stay silent, because a rule that fires on every mention of a key prefix in a comment is worse than no rule.

Two named contributors, newest first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)