### PR TITLE
docs: correct the freeze dates to what the commands actually say

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ separately (currently `1.2.0`) and changes additively.
 
 ## [Unreleased]
 
-## [0.7.0] - 2026-08-26
+## [0.7.0] - 2026-08-27
 
 Honesty release. Two published claims were false on the live path and four
 known false positives were shipping under a freeze. All six are fixed, and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ investor material. Never in landing-page copy or a cold first line.
 
 ---
 
-## The detection freeze, restarted 2026-08-26
+## The detection freeze, restarted 2026-08-30
 
 **Do not edit these files.** They are hashed into the ruleset fingerprint, and
 changing any of them restarts the four-week dogfood clock that gates beta.
@@ -36,12 +36,13 @@ apps/orchestrator/agentmetry/core/audit/mitre.py
 apps/orchestrator/agentmetry/policies/detection/manifest.yaml
 ```
 
-The clock **restarted at 0.7.0 on 2026-08-26**, and the freeze runs again from
+The clock **restarted on 2026-08-30**, after 0.7.0, and the freeze runs again from
 there. The previous run reached 3 of 4 green weeks and was ended deliberately:
 four known false positives (#44, #49, #50, #51) were shipping as criticals to
 the first external tester, and a clean gate measured against a ruleset that
 fires critical on `.env.example` is not worth the weeks it took. Earliest close
-is now **2026-09-23**. Check it any time:
+is **2026-09-26**, the end of week four. Check it any time, and trust
+this command over this file:
 
 ```bash
 apps/orchestrator/.venv/Scripts/python.exe -m agentmetry.cli dogfood
@@ -57,13 +58,12 @@ apps/orchestrator/.venv/Scripts/python.exe -c "from agentmetry.core.audit.dogfoo
 # expect 15846a0915769d4a
 ```
 
-Four of the five parked detection-precision bugs were fixed in 0.7.0 (#44,
-#49, #50, #51), which is why the clock restarted. Still parked: [#44](https://github.com/blitzcrieg1/agentmetry/issues/44),
-[#49](https://github.com/blitzcrieg1/agentmetry/issues/49),
-[#50](https://github.com/blitzcrieg1/agentmetry/issues/50),
-[#51](https://github.com/blitzcrieg1/agentmetry/issues/51),
-[#55](https://github.com/blitzcrieg1/agentmetry/issues/55). Land them as one
-pass with #55, so the fingerprint moves once more and not again.
+Four of the five parked detection-precision bugs were fixed in 0.7.0 and are
+closed: #44, #49, #50, #51. Fixing them is why the clock restarted.
+
+**Still parked: [#55](https://github.com/blitzcrieg1/agentmetry/issues/55)
+alone.** It is the last change that will move the fingerprint, so land it in
+one pass rather than piecemeal, and expect another restart when it lands.
 
 Files in `detection/` that are **not** frozen and are safe to edit:
 `disposition.py`, `live.py`, `live_store.py`, `benchmark.py`, `yaml_rules.py`,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,12 +34,12 @@ Two rules, so it does not happen again.
 
 | | |
 |---|---|
-| Version | 0.7.0 on PyPI, released 2026-08-26 |
+| Version | 0.7.0 on PyPI, released 2026-08-27 |
 | Canonical event schema | 1.2.0, additive |
 | Detection rules | 14 published sequence rules plus 1 experimental, ATT&CK on every event, ATLAS on the AI-specific subset. All 14 exported as Sigma, generated from the engine |
 | Benchmark | 54 recorded sessions, 26 attack and 28 benign, 0 missed and 0 false positives. The four known FPs are now *in* the corpus |
 | Tests | 1148 passing, 81% coverage, floor enforced in CI |
-| Dogfood gate | **0 of 4.** Clock restarted 2026-08-26 at 0.7.0, deliberately, to fix four shipping false positives |
+| Dogfood gate | **0 of 4.** Clock restarted 2026-08-30, after 0.7.0, deliberately, to fix four shipping false positives |
 | Own trail | 27,504 hash-chained lines, 24 external anchors |
 | Adoption | Public alpha. No design partner tenant yet, no reference customer |
 
@@ -73,7 +73,7 @@ Declare beta when all four are true. Two are.
 
 | Gate | Status |
 |---|---|
-| Four consecutive green dogfood weeks | **0 of 4.** Restarted 2026-08-26. Earliest close **2026-09-23** |
+| Four consecutive green dogfood weeks | **0 of 4.** Restarted 2026-08-30. Earliest close **2026-09-26** |
 | `agentmetry verify --trail` demonstrated in the README | Done |
 | `agentmetry doctor` green on three distinct Windows 11 setups | **1 of 3.** Needs two machines that are not the maintainer's |
 | Public claims match shipped behaviour | Done. `/compare`, the limitations section and the benchmark all state numbers the reader can reproduce |
@@ -84,7 +84,7 @@ side effect, which is another argument for the ordering below.
 
 ---
 
-## Now (through 2026-09-23)
+## Now (through 2026-09-26)
 
 Ordered by what unblocks the most. Only the first item is not code, and it is
 the most important one on the page.
@@ -95,7 +95,7 @@ the most important one on the page.
 | Detection precision pass | [#44](https://github.com/blitzcrieg1/agentmetry/issues/44) [#49](https://github.com/blitzcrieg1/agentmetry/issues/49) [#50](https://github.com/blitzcrieg1/agentmetry/issues/50) [#51](https://github.com/blitzcrieg1/agentmetry/issues/51) [#55](https://github.com/blitzcrieg1/agentmetry/issues/55) | Five false-positive sources in frozen files. Land as one pass with #55 first, after the dogfood gate closes, so the ruleset fingerprint moves once |
 | Evidence pack integrity covers `meta` | [#75](https://github.com/blitzcrieg1/agentmetry/issues/75) | The date range on an evidence pack can currently be rewritten without breaking the hash. Needs a schema bump so existing packs keep verifying |
 
-**Held deliberately until 2026-09-23:** anything that edits
+**Held deliberately until 2026-09-26:** anything that edits
 `detection/rules.py`, `detection/traits.py`, `detection/engine.py` or
 `audit/mitre.py`, and anything that edits the detection manifest those four are
 hashed alongside. Together they are the ruleset fingerprint, and moving it

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -1,6 +1,6 @@
 # Agentmetry: recording what AI coding agents actually did
 
-**A technical whitepaper.** Version 0.7.0, 2026-08-26.
+**A technical whitepaper.** Version 0.7.0, 2026-08-27.
 
 Every number in this document comes from a command in the repository. Where a
 claim cannot be reproduced, it is not made.


### PR DESCRIPTION
Three date errors, all from one cause: dates written into documents before running the command that would have given the real one.

## The clock was never restarted

`CLAUDE.md` and `ROADMAP.md` announced a restart on 2026-08-26. Nothing had restarted it. `agentmetry dogfood` was still measuring from 2026-08-08 and correctly refusing to pass:

```
RULESET CHANGED since the clock started, so these weeks did not all
measure the same product and the run cannot pass.
```

So the documents described a state the tool did not hold. Running `dogfood --start --restart` set it to **2026-08-30**, which makes earliest close **2026-09-26**, the end of week four, not 2026-09-23.

```
Week  Dates                      Days  Events  Sessions  Detect  Untriaged  Verdict
1     2026-08-30 to 2026-09-05    1      201        6       0          0  IN PROGRESS
```

## The release date was a day out

0.7.0 was tagged and published **2026-08-27**, confirmed against the tag and the PyPI upload time. The CHANGELOG heading, the ROADMAP version row and the whitepaper all said 2026-08-26, because that was the date printed on the briefing document I was working from and I took it for today's.

## The parked list was stale

`CLAUDE.md` still named #44, #49, #50 and #51 as parked, after 0.7.0 fixed and closed all four. **Only #55 remains**, and it is now the last change that will move the fingerprint, so it should land in one pass.

## Worth naming

This is precisely the drift `CLAUDE.md` exists to prevent, committed inside `CLAUDE.md`, during the week whose releases were about making claims true. The command was right the whole time and was never asked.

The freeze section now says to trust `agentmetry dogfood` over the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)