### PR TITLE
feat(cli): add detections command for triage

### DIFF
--- a/apps/orchestrator/agentmetry/cli/__init__.py
+++ b/apps/orchestrator/agentmetry/cli/__init__.py
@@ -250,6 +250,10 @@ def cmd_detections(args: argparse.Namespace) -> int:
     except Exception:
         print("Not running - start Agentmetry first (detections reads via the API).")
         return 1
+    if not data.get("enabled", True):
+        print("Audit export is disabled, so no sessions are recorded.")
+        print("Set AGENTMETRY_AUDIT_EXPORT_ENABLED=1 and restart.")
+        return 1
     detections = data.get("detections") or []
     if not detections:
         print(f"No detections for {args.correlation_id}.")

--- a/apps/orchestrator/agentmetry/cli/__init__.py
+++ b/apps/orchestrator/agentmetry/cli/__init__.py
@@ -241,6 +241,34 @@ def cmd_stats(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_detections(args: argparse.Namespace) -> int:
+    try:
+        data = httpx.get(
+            f"{_base_url(args.port)}/api/v1/audit/detections/{args.correlation_id}",
+            timeout=10.0,
+        ).json()
+    except Exception:
+        print("Not running - start Agentmetry first (detections reads via the API).")
+        return 1
+    detections = data.get("detections") or []
+    if not detections:
+        print(f"No detections for {args.correlation_id}.")
+        return 0
+    rule_width = max(len("Rule"), *(len(str(d.get("rule_id", ""))) for d in detections))
+    severity_width = max(
+        len("Severity"), *(len(str(d.get("severity", ""))) for d in detections)
+    )
+    print(f"{'Rule':<{rule_width}}  {'Severity':<{severity_width}}  Summary")
+    print(f"{'-' * rule_width}  {'-' * severity_width}  {'-' * len('Summary')}")
+    for detection in detections:
+        print(
+            f"{str(detection.get('rule_id', '')):<{rule_width}}  "
+            f"{str(detection.get('severity', '')):<{severity_width}}  "
+            f"{detection.get('summary', '')}"
+        )
+    return 0
+
+
 def cmd_logs(args: argparse.Namespace) -> int:
     log = _DATA_DIR / "logs" / "orchestrator.log"
     if not log.exists():
@@ -1132,6 +1160,8 @@ def main(argv: list[str] | None = None) -> int:
     sub.add_parser("status", help="orchestrator health and audit export status")
     stats = sub.add_parser("stats", help="audit trail metrics for dogfood (events, detections)")
     stats.add_argument("--days", type=int, default=7)
+    detections = sub.add_parser("detections", help="list detections for one session")
+    detections.add_argument("correlation_id", help="correlation_id / session id")
     logs = sub.add_parser("logs", help="tail the orchestrator log")
     logs.add_argument("-n", "--lines", type=int, default=50)
     logs.add_argument("-f", "--follow", action="store_true")
@@ -1273,6 +1303,7 @@ def main(argv: list[str] | None = None) -> int:
         "hook": cmd_hook,
         "status": cmd_status,
         "stats": cmd_stats,
+        "detections": cmd_detections,
         "logs": cmd_logs,
         "backup": cmd_backup,
         "restore": cmd_restore,

--- a/apps/orchestrator/tests/test_cli_commands.py
+++ b/apps/orchestrator/tests/test_cli_commands.py
@@ -395,6 +395,26 @@ def test_detections_reports_an_empty_session_cleanly(monkeypatch, capsys):
     assert "No detections" in capsys.readouterr().out
 
 
+def test_detections_explains_a_disabled_export(monkeypatch, capsys):
+    from agentmetry import cli
+
+    class Resp:
+        @staticmethod
+        def json():
+            return {
+                "detections": [],
+                "correlation_id": "session-7",
+                "enabled": False,
+                "count": 0,
+            }
+
+    monkeypatch.setattr(cli.httpx, "get", lambda *_args, **_kwargs: Resp())
+    assert main(["detections", "session-7"]) == 1
+    out = capsys.readouterr().out
+    assert "Audit export is disabled" in out
+    assert "AGENTMETRY_AUDIT_EXPORT_ENABLED=1" in out
+
+
 def test_detections_says_so_when_the_orchestrator_is_down(monkeypatch, capsys):
     from agentmetry import cli
 

--- a/apps/orchestrator/tests/test_cli_commands.py
+++ b/apps/orchestrator/tests/test_cli_commands.py
@@ -316,6 +316,96 @@ def test_stats_explains_a_disabled_export(monkeypatch, capsys):
     assert "disabled" in capsys.readouterr().out
 
 
+def _api_detection(rule_id: str, severity: str, summary: str, seen: str) -> dict:
+    return {
+        "rule_id": rule_id,
+        "title": rule_id.replace("-", " ").title(),
+        "severity": severity,
+        "summary": summary,
+        "correlation_id": "session-7",
+        "tactic_ids": [],
+        "technique_ids": [],
+        "event_ids": [],
+        "first_seen_utc": seen,
+        "last_seen_utc": seen,
+        "disposition": None,
+    }
+
+
+def test_detections_prints_the_ranked_api_results(monkeypatch, capsys):
+    from agentmetry import cli
+
+    requested = []
+
+    class Resp:
+        @staticmethod
+        def json():
+            return {
+                "detections": [
+                    _api_detection(
+                        "credential-exfil",
+                        "critical",
+                        "Credentials were read before network egress.",
+                        "2026-08-31T01:00:00+00:00",
+                    ),
+                    _api_detection(
+                        "guardrail-bypass",
+                        "high",
+                        "An agent modified its own instructions.",
+                        "2026-08-31T01:02:00+00:00",
+                    ),
+                ],
+                "correlation_id": "session-7",
+                "enabled": True,
+                "count": 2,
+                "untriaged": 2,
+            }
+
+    def get(url, **_kwargs):
+        requested.append(url)
+        return Resp()
+
+    monkeypatch.setattr(cli.httpx, "get", get)
+    assert main(["detections", "session-7"]) == 0
+    assert requested == ["http://127.0.0.1:8000/api/v1/audit/detections/session-7"]
+    lines = capsys.readouterr().out.splitlines()
+    assert "Rule" in lines[0] and "Severity" in lines[0] and "Summary" in lines[0]
+    assert "credential-exfil" in lines[2]
+    assert "critical" in lines[2]
+    assert "Credentials were read before network egress." in lines[2]
+    assert "guardrail-bypass" in lines[3]
+
+
+def test_detections_reports_an_empty_session_cleanly(monkeypatch, capsys):
+    from agentmetry import cli
+
+    class Resp:
+        @staticmethod
+        def json():
+            return {
+                "detections": [],
+                "correlation_id": "session-empty",
+                "enabled": True,
+                "count": 0,
+                "untriaged": 0,
+            }
+
+    monkeypatch.setattr(cli.httpx, "get", lambda *_args, **_kwargs: Resp())
+    assert main(["detections", "session-empty"]) == 0
+    assert "No detections" in capsys.readouterr().out
+
+
+def test_detections_says_so_when_the_orchestrator_is_down(monkeypatch, capsys):
+    from agentmetry import cli
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(cli.httpx, "get", boom)
+    assert main(["detections", "session-7"]) == 1
+    assert "Not running" in capsys.readouterr().out
+
+
 # --------------------------------------------------------------------------
 # small surfaces that still have an exit-code contract
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `agentmetry detections <correlation_id>` so a session's correlated
detections can be inspected without calling the audit API manually.

- Calls `GET /api/v1/audit/detections/{correlation_id}`
- Preserves the API's severity-ranked result order
- Renders rule ID, severity, and summary as a readable table
- Reports sessions with no detections cleanly and exits successfully
- Returns a clear message and non-zero exit code when the orchestrator is unavailable

## Why

The detections endpoint already supports session-level incident triage, but
CLI users currently need to construct the HTTP request themselves. This adds
the one-line workflow described in the issue while keeping ranking logic in
the detection API.

## Testing

- `python -m ruff check agentmetry tests tools`
- `python -m pytest -q` — 1154 passed, 1 skipped
- Manually verified a seeded session with multiple detections
- Manually verified an unknown session returns `No detections`
- Manually verified an unavailable server returns exit code `1`

## Scope

This is limited to the CLI command and its focused tests. It does not change
the detections API, detection rules, event schema, or dashboard.

Closes #8