### PR TITLE
fix(install): a fresh Windows install was broken three ways

### DIFF
--- a/apps/orchestrator/pyproject.toml
+++ b/apps/orchestrator/pyproject.toml
@@ -34,7 +34,12 @@ dependencies = [
     "websockets>=14.0",
     "sqlalchemy>=2.0.0",
     "aiosqlite>=0.20.0",
-    "mcp>=1.2",
+    # Upper bound is load-bearing, not caution. MCP 2.0 removed
+    # `mcp.server.fastmcp.FastMCP`, which `tools/vault_fs_server.py` imports,
+    # so an unconstrained `>=1.2` resolved to 2.x on any fresh install and the
+    # bundled server failed on first run (issue #138). Lift this when that
+    # import is ported to the 2.x API, not before.
+    "mcp>=1.2,<2",
     # Windows ships no IANA timezone database, so `zoneinfo` cannot resolve
     # AGENTMETRY_BUSINESS_TZ there without this. Without it the off-hours rule
     # silently fell back to UTC and produced wrong findings on the platform this

--- a/apps/orchestrator/tests/test_powershell_encoding.py
+++ b/apps/orchestrator/tests/test_powershell_encoding.py
@@ -1,0 +1,102 @@
+"""Windows PowerShell 5.1 must be able to parse the installers.
+
+PowerShell 5.1 is the version that ships with Windows and is what the documented
+install command runs. It reads a file with no byte order mark using the system
+ANSI code page, not UTF-8. So a single non-ASCII character in a BOM-less script
+arrives as mojibake, and if it lands inside a string literal the file fails to
+*parse*, which means the installer body never begins executing.
+
+That happened. `scripts/install.ps1` contained an em dash, and the documented
+command failed on a fresh clone with "The string is missing the terminator"
+pointing at a line that was perfectly well formed in UTF-8 (issue #133). Seven
+of the eleven scripts carried the same character, and `install_qoder_hooks.ps1`
+legitimately contains CJK in a product name, so removing em dashes alone would
+not have been enough.
+
+Two independent guarantees, because either alone can be undone by accident:
+
+* every `.ps1` file starts with a UTF-8 BOM, so PowerShell 5.1 decodes it
+  correctly whatever it contains
+* no `.ps1` file contains an em dash, which is a house rule for public copy
+  anyway and is the specific character that broke it
+
+The parse itself is checked by CI on Windows, not here, because a Linux runner
+has no PowerShell 5.1 to parse with.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[3] / "scripts"
+BOM = b"\xef\xbb\xbf"
+
+
+def _scripts() -> list[Path]:
+    if not SCRIPTS.is_dir():
+        pytest.skip(f"scripts directory not found at {SCRIPTS}")
+    found = sorted(SCRIPTS.glob("*.ps1"))
+    if not found:
+        pytest.skip("no PowerShell scripts to check")
+    return found
+
+
+def test_every_powershell_script_has_a_utf8_bom():
+    """Without it, PowerShell 5.1 decodes as ANSI and non-ASCII becomes mojibake."""
+    missing = [p.name for p in _scripts() if not p.read_bytes().startswith(BOM)]
+    assert not missing, (
+        f"no UTF-8 BOM: {missing}. Windows PowerShell 5.1 will read these as "
+        "the system ANSI code page, and any non-ASCII character will break the "
+        "parse before the script runs."
+    )
+
+
+def test_no_em_dash_in_powershell_scripts():
+    """The exact character that broke the documented install command."""
+    offenders = []
+    for path in _scripts():
+        text = path.read_bytes().decode("utf-8")
+        for number, line in enumerate(text.splitlines(), 1):
+            if "—" in line:
+                offenders.append(f"{path.name}:{number}")
+    assert not offenders, (
+        f"em dash in: {offenders}. Use a comma, a colon or a full stop. This is "
+        "the house rule for public copy, and it is also what made install.ps1 "
+        "unparseable on the default Windows shell."
+    )
+
+
+def test_hook_installers_prefer_the_orchestrator_venv():
+    """Global python has no `agentmetry` on a clean machine.
+
+    `install.ps1` builds the venv and installs into it, so a hook installer that
+    resolves bare `python` fails with ModuleNotFoundError on exactly the machine
+    a first-time user is running it from.
+    """
+    offenders = []
+    for path in sorted(SCRIPTS.glob("install_*_hooks.ps1")):
+        text = path.read_bytes().decode("utf-8")
+        if "Get-Command python" in text and ".venv\\Scripts\\python.exe" not in text:
+            offenders.append(path.name)
+    assert not offenders, (
+        f"resolves global python with no venv fallback: {offenders}"
+    )
+
+
+def test_top_level_installer_checks_hook_exit_codes():
+    """A native command's exit code does not trip $ErrorActionPreference.
+
+    Each hook installer checks its own `$LASTEXITCODE`. That is worth nothing if
+    the caller ignores it, which is how `install.ps1` printed "Install complete"
+    and exited 0 after both hook installers had failed.
+    """
+    text = (SCRIPTS / "install.ps1").read_bytes().decode("utf-8")
+    hook_block = text.split("Installing IDE hooks", 1)
+    assert len(hook_block) == 2, "hook install step not found in install.ps1"
+    after = hook_block[1].split("Write-Step", 1)[0]
+    assert "$LASTEXITCODE" in after, (
+        "install.ps1 runs the hook installers without checking their exit code, "
+        "so a failed hook install still reports success."
+    )

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,4 +1,4 @@
-# Agentmetry — Windows one-flow install (orchestrator + dashboard + IDE hooks).
+﻿# Agentmetry: Windows one-flow install (orchestrator + dashboard + IDE hooks).
 #
 # Usage (from repo root):
 #   powershell -ExecutionPolicy Bypass -File scripts\install.ps1
@@ -107,7 +107,7 @@ Pop-Location
 if (-not $SkipDashboard) {
     Write-Step "Installing dashboard dependencies"
     Push-Location $DashRoot
-    # npm ci installs exactly what package-lock.json pins — reproducible on
+    # npm ci installs exactly what package-lock.json pins, which is reproducible on
     # fresh machines, which is what an installer is for.
     & npm ci --no-fund --no-audit
     Pop-Location
@@ -115,8 +115,24 @@ if (-not $SkipDashboard) {
 
 if (-not $SkipHooks) {
     Write-Step "Installing IDE hooks (Claude Code + Cursor)"
-    & powershell -ExecutionPolicy Bypass -File (Join-Path $RepoRoot "scripts\install_claude_hooks.ps1")
-    & powershell -ExecutionPolicy Bypass -File (Join-Path $RepoRoot "scripts\install_cursor_hooks.ps1")
+    # Each hook installer already checks $LASTEXITCODE and exits non-zero on
+    # failure. That was useless while this caller ignored it: both could fail
+    # with ModuleNotFoundError and this script still printed "Install complete"
+    # and exited 0, so a user, and any deployment automation, was told hooks
+    # were installed when nothing had been (issue #137).
+    #
+    # A recorder whose whole claim is that removal changes what it says about
+    # itself cannot ship an installer that reports success after a failure.
+    foreach ($hookScript in @("install_claude_hooks.ps1", "install_cursor_hooks.ps1")) {
+        & powershell -ExecutionPolicy Bypass -File (Join-Path $RepoRoot "scripts\$hookScript")
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host ""
+            Write-Host "$hookScript FAILED (exit $LASTEXITCODE)." -ForegroundColor Red
+            Write-Host "Hooks are NOT installed, so nothing will be recorded." -ForegroundColor Red
+            Write-Host "Re-run with -SkipHooks to install everything else, then fix hooks separately."
+            exit $LASTEXITCODE
+        }
+    }
 }
 
 if (-not $NoDoctor) {
@@ -136,7 +152,7 @@ Write-Host "  5. Trail:     scripts\agentmetry.bat verify --trail apps\orchestra
 Write-Host "  6. Stats:      scripts\agentmetry.bat stats --days 7"
 Write-Host ""
 if ($ToolPolicyBlock -or $DlpBlock) {
-    Write-Host "Hook enforcement enabled in apps\orchestrator\.env — restart Claude Code / Cursor after hooks install." -ForegroundColor Yellow
+    Write-Host "Hook enforcement enabled in apps\orchestrator\.env. Restart Claude Code / Cursor after hooks install." -ForegroundColor Yellow
 }
 if (-not $SkipHooks) {
     Write-Host "Fully quit and restart Claude Code / Cursor so hooks load." -ForegroundColor Yellow

--- a/scripts/install_antigravity_hooks.ps1
+++ b/scripts/install_antigravity_hooks.ps1
@@ -1,4 +1,4 @@
-# Install Agentmetry hooks for Google Antigravity 2.0 (global + scratch workspace).
+﻿# Install Agentmetry hooks for Google Antigravity 2.0 (global + scratch workspace).
 #
 # Usage: powershell -ExecutionPolicy Bypass -File scripts\install_antigravity_hooks.ps1
 
@@ -6,7 +6,16 @@ $ErrorActionPreference = "Stop"
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 $Ingest = Join-Path $RepoRoot "scripts\agentmetry_ingest.py"
 $Wrapper = Join-Path $RepoRoot "scripts\agentmetry_antigravity_hook.cmd"
-$Python = (Get-Command python -ErrorAction Stop).Source
+# Prefer the orchestrator venv. `install.ps1` creates it and installs
+# Agentmetry into it, but global python usually has no `agentmetry` module, so
+# resolving `python` here failed with ModuleNotFoundError on a clean machine
+# while the top-level installer still reported success (issue #137).
+$VenvPython = Join-Path $RepoRoot "apps\orchestrator\.venv\Scripts\python.exe"
+if (Test-Path $VenvPython) {
+    $Python = $VenvPython
+} else {
+    $Python = (Get-Command python -ErrorAction Stop).Source
+}
 
 @(
     "@echo off",

--- a/scripts/install_chinese_hooks.ps1
+++ b/scripts/install_chinese_hooks.ps1
@@ -1,11 +1,20 @@
-# Install Agentmetry hooks for all supported Chinese CLI agents.
+﻿# Install Agentmetry hooks for all supported Chinese CLI agents.
 # Skips agents whose config dirs are missing (not installed on this machine).
 #
 # Usage: powershell -ExecutionPolicy Bypass -File scripts\install_chinese_hooks.ps1
 
 $ErrorActionPreference = "Stop"
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
-$Python = (Get-Command python -ErrorAction Stop).Source
+# Prefer the orchestrator venv. `install.ps1` creates it and installs
+# Agentmetry into it, but global python usually has no `agentmetry` module, so
+# resolving `python` here failed with ModuleNotFoundError on a clean machine
+# while the top-level installer still reported success (issue #137).
+$VenvPython = Join-Path $RepoRoot "apps\orchestrator\.venv\Scripts\python.exe"
+if (Test-Path $VenvPython) {
+    $Python = $VenvPython
+} else {
+    $Python = (Get-Command python -ErrorAction Stop).Source
+}
 $Bootstrap = Join-Path $RepoRoot "apps\orchestrator\agentmetry\core\audit\hook_bootstrap.py"
 
 $targets = @(

--- a/scripts/install_claude_hooks.ps1
+++ b/scripts/install_claude_hooks.ps1
@@ -1,4 +1,4 @@
-# Install Agentmetry hooks for Claude Code — GLOBAL (~/.claude/settings.json).
+﻿# Install Agentmetry hooks for Claude Code, GLOBAL (~/.claude/settings.json).
 # Merges into your existing settings (theme, permissions, MCP servers, env are
 # preserved). Applies to every Claude Code project. Idempotent.
 #
@@ -8,7 +8,16 @@
 
 $ErrorActionPreference = "Stop"
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
-$Python = (Get-Command python -ErrorAction Stop).Source
+# Prefer the orchestrator venv. `install.ps1` creates it and installs
+# Agentmetry into it, but global python usually has no `agentmetry` module, so
+# resolving `python` here failed with ModuleNotFoundError on a clean machine
+# while the top-level installer still reported success (issue #137).
+$VenvPython = Join-Path $RepoRoot "apps\orchestrator\.venv\Scripts\python.exe"
+if (Test-Path $VenvPython) {
+    $Python = $VenvPython
+} else {
+    $Python = (Get-Command python -ErrorAction Stop).Source
+}
 
 & $Python (Join-Path $RepoRoot "apps\orchestrator\agentmetry\core\audit\hook_bootstrap.py")
 

--- a/scripts/install_codebuddy_hooks.ps1
+++ b/scripts/install_codebuddy_hooks.ps1
@@ -1,8 +1,17 @@
-# Install Agentmetry hooks for Tencent CodeBuddy — GLOBAL (~/.codebuddy/settings.json).
+﻿# Install Agentmetry hooks for Tencent CodeBuddy, GLOBAL (~/.codebuddy/settings.json).
 
 $ErrorActionPreference = "Stop"
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
-$Python = (Get-Command python -ErrorAction Stop).Source
+# Prefer the orchestrator venv. `install.ps1` creates it and installs
+# Agentmetry into it, but global python usually has no `agentmetry` module, so
+# resolving `python` here failed with ModuleNotFoundError on a clean machine
+# while the top-level installer still reported success (issue #137).
+$VenvPython = Join-Path $RepoRoot "apps\orchestrator\.venv\Scripts\python.exe"
+if (Test-Path $VenvPython) {
+    $Python = $VenvPython
+} else {
+    $Python = (Get-Command python -ErrorAction Stop).Source
+}
 
 & $Python (Join-Path $RepoRoot "apps\orchestrator\agentmetry\core\audit\hook_bootstrap.py") codebuddy
 

--- a/scripts/install_codex_hooks.ps1
+++ b/scripts/install_codex_hooks.ps1
@@ -1,4 +1,4 @@
-# Install Agentmetry hooks for OpenAI Codex CLI - GLOBAL (~/.codex/hooks.json).
+﻿# Install Agentmetry hooks for OpenAI Codex CLI - GLOBAL (~/.codex/hooks.json).
 # Merges into your existing hooks; your own groups are preserved. Idempotent.
 #
 # Usage: powershell -ExecutionPolicy Bypass -File scripts\install_codex_hooks.ps1
@@ -9,7 +9,16 @@
 
 $ErrorActionPreference = "Stop"
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
-$Python = (Get-Command python -ErrorAction Stop).Source
+# Prefer the orchestrator venv. `install.ps1` creates it and installs
+# Agentmetry into it, but global python usually has no `agentmetry` module, so
+# resolving `python` here failed with ModuleNotFoundError on a clean machine
+# while the top-level installer still reported success (issue #137).
+$VenvPython = Join-Path $RepoRoot "apps\orchestrator\.venv\Scripts\python.exe"
+if (Test-Path $VenvPython) {
+    $Python = $VenvPython
+} else {
+    $Python = (Get-Command python -ErrorAction Stop).Source
+}
 $Bootstrap = Join-Path $RepoRoot "apps\orchestrator\agentmetry\core\audit\hook_bootstrap.py"
 
 if (-not (Test-Path $Bootstrap)) {

--- a/scripts/install_cursor_hooks.ps1
+++ b/scripts/install_cursor_hooks.ps1
@@ -1,4 +1,4 @@
-# Install Agentmetry hooks for Cursor — GLOBAL (~/.cursor/hooks.json).
+﻿# Install Agentmetry hooks for Cursor, GLOBAL (~/.cursor/hooks.json).
 # Applies to every Cursor workspace, not just this repo.
 #
 # Usage: powershell -ExecutionPolicy Bypass -File scripts\install_cursor_hooks.ps1
@@ -7,7 +7,16 @@
 
 $ErrorActionPreference = "Stop"
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
-$Python = (Get-Command python -ErrorAction Stop).Source
+# Prefer the orchestrator venv. `install.ps1` creates it and installs
+# Agentmetry into it, but global python usually has no `agentmetry` module, so
+# resolving `python` here failed with ModuleNotFoundError on a clean machine
+# while the top-level installer still reported success (issue #137).
+$VenvPython = Join-Path $RepoRoot "apps\orchestrator\.venv\Scripts\python.exe"
+if (Test-Path $VenvPython) {
+    $Python = $VenvPython
+} else {
+    $Python = (Get-Command python -ErrorAction Stop).Source
+}
 
 & $Python (Join-Path $RepoRoot "apps\orchestrator\agentmetry\core\audit\hook_bootstrap.py")
 

--- a/scripts/install_kimi_hooks.ps1
+++ b/scripts/install_kimi_hooks.ps1
@@ -1,11 +1,20 @@
-# Install Agentmetry hooks for Kimi Code — GLOBAL (~/.kimi-code/config.toml).
+﻿# Install Agentmetry hooks for Kimi Code, GLOBAL (~/.kimi-code/config.toml).
 # Inserts a managed [[hooks]] block (other config.toml keys are preserved).
 #
 # Usage: powershell -ExecutionPolicy Bypass -File scripts\install_kimi_hooks.ps1
 
 $ErrorActionPreference = "Stop"
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
-$Python = (Get-Command python -ErrorAction Stop).Source
+# Prefer the orchestrator venv. `install.ps1` creates it and installs
+# Agentmetry into it, but global python usually has no `agentmetry` module, so
+# resolving `python` here failed with ModuleNotFoundError on a clean machine
+# while the top-level installer still reported success (issue #137).
+$VenvPython = Join-Path $RepoRoot "apps\orchestrator\.venv\Scripts\python.exe"
+if (Test-Path $VenvPython) {
+    $Python = $VenvPython
+} else {
+    $Python = (Get-Command python -ErrorAction Stop).Source
+}
 
 & $Python (Join-Path $RepoRoot "apps\orchestrator\agentmetry\core\audit\hook_bootstrap.py") kimi
 

--- a/scripts/install_qoder_hooks.ps1
+++ b/scripts/install_qoder_hooks.ps1
@@ -1,8 +1,17 @@
-# Install Agentmetry hooks for Qoder (通义灵码) — GLOBAL (~/.qoder/settings.json).
+﻿# Install Agentmetry hooks for Qoder (通义灵码), GLOBAL (~/.qoder/settings.json).
 
 $ErrorActionPreference = "Stop"
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
-$Python = (Get-Command python -ErrorAction Stop).Source
+# Prefer the orchestrator venv. `install.ps1` creates it and installs
+# Agentmetry into it, but global python usually has no `agentmetry` module, so
+# resolving `python` here failed with ModuleNotFoundError on a clean machine
+# while the top-level installer still reported success (issue #137).
+$VenvPython = Join-Path $RepoRoot "apps\orchestrator\.venv\Scripts\python.exe"
+if (Test-Path $VenvPython) {
+    $Python = $VenvPython
+} else {
+    $Python = (Get-Command python -ErrorAction Stop).Source
+}
 
 & $Python (Join-Path $RepoRoot "apps\orchestrator\agentmetry\core\audit\hook_bootstrap.py") qoder
 

--- a/scripts/install_qwen_hooks.ps1
+++ b/scripts/install_qwen_hooks.ps1
@@ -1,11 +1,20 @@
-# Install Agentmetry hooks for Qwen Code — GLOBAL (~/.qwen/settings.json).
+﻿# Install Agentmetry hooks for Qwen Code, GLOBAL (~/.qwen/settings.json).
 # Merges into your existing settings (providers, MCP servers, env are preserved).
 #
 # Usage: powershell -ExecutionPolicy Bypass -File scripts\install_qwen_hooks.ps1
 
 $ErrorActionPreference = "Stop"
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
-$Python = (Get-Command python -ErrorAction Stop).Source
+# Prefer the orchestrator venv. `install.ps1` creates it and installs
+# Agentmetry into it, but global python usually has no `agentmetry` module, so
+# resolving `python` here failed with ModuleNotFoundError on a clean machine
+# while the top-level installer still reported success (issue #137).
+$VenvPython = Join-Path $RepoRoot "apps\orchestrator\.venv\Scripts\python.exe"
+if (Test-Path $VenvPython) {
+    $Python = $VenvPython
+} else {
+    $Python = (Get-Command python -ErrorAction Stop).Source
+}
 
 & $Python (Join-Path $RepoRoot "apps\orchestrator\agentmetry\core\audit\hook_bootstrap.py") qwen
 

--- a/scripts/publish_anchor.ps1
+++ b/scripts/publish_anchor.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Take a checkpoint of the trail and publish it to the anchor repository.
 


### PR DESCRIPTION
Closes #133, closes #137, closes #138.

All three found by @hossainzarif23 while picking up a good first issue. Finding that the project does not install is considerably more useful than the issue they were assigned, and it is the failure mode nobody on the inside ever hits.

## #133 The installer did not parse on the default Windows shell

Windows PowerShell 5.1 is what ships with Windows and what the documented command runs. It reads a BOM-less file using the system ANSI code page, so the **em dash** on line 139 arrived as mojibake inside a string literal:

```
The string is missing the terminator: ".
```

A parse error, so the installer body never began executing. Seven of eleven scripts carried the same character.

The house rule already bans em dashes in public copy because they read as machine-written. The better reason turns out to be that one stopped the installer from running.

Fixed by making the prose ASCII **and** adding a UTF-8 BOM to every script, because `install_qoder_hooks.ps1` legitimately contains CJK and removing em dashes alone would not have saved it.

Verified against the shell that was failing:

```
Windows PowerShell 5.1.26100.8875: 0 parse failures across 11 scripts
```

## #137 Hooks failed, and the installer said it succeeded

Two bugs stacked.

Hook installers resolved bare `python`. `install.ps1` creates a venv and installs Agentmetry into it, so on a machine with no global install both failed with `ModuleNotFoundError`. They now prefer the venv and fall back to global.

Worse: **`install.ps1` ignored their exit codes.** Every hook installer already checks `$LASTEXITCODE`, with a comment explaining that a native command's exit code does not trip `$ErrorActionPreference`. That lesson was learned in the child script and never applied in the parent, so both could fail and this still printed `Install complete`, told the user to restart their editor, and exited 0.

A recorder whose entire claim is that removal changes what it says about itself cannot ship an installer that reports success after a failure.

## #138 `mcp>=1.2` resolves to 2.x

Latest on PyPI is **2.1.1**. MCP 2.0 removed `mcp.server.fastmcp.FastMCP`, which `tools/vault_fs_server.py` imports, so the bundled server broke on every fresh install. Pinned `<2` with the reason attached, to be lifted when the import is ported rather than when someone tidies constraints.

## Guards

Four tests in `test_powershell_encoding.py`: BOM on every script, no em dash, hook installers prefer the venv, and `install.ps1` checks the hook exit code. All three bugs are invisible until a stranger installs on a clean machine, which is exactly when you cannot afford them.

1158 tests, ruff clean, ruleset fingerprint unchanged at `15846a0915769d4a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)