### PR TITLE
fix(mcp): a re-baseline is not a first sighting

### DIFF
--- a/apps/orchestrator/agentmetry/core/audit/ingest.py
+++ b/apps/orchestrator/agentmetry/core/audit/ingest.py
@@ -238,16 +238,28 @@ def build_schema_canonical(
     server, fingerprint, tool_count = fields.server, fields.fingerprint, fields.tool_count
     server_version, list_changed = fields.server_version, fields.list_changed
     outcome = "changed" if status == "changed" else "success"
-    reason = (
-        "MCP tool schema changed; config may be unchanged (rug-pull candidate)"
-        if status == "changed"
-        else "MCP tool schema observed"
-    )
+    _REASONS = {
+        "changed": "MCP tool schema changed; config may be unchanged (rug-pull candidate)",
+        # Says what it is and what it is not. A re-baseline adopts whatever the
+        # server serves today without comparing it to anything, so if the server
+        # was already poisoned before our hashing changed, this event is the
+        # moment that state became the trusted one. `new` would have hidden that
+        # behind a word that also means "nothing was ever wrong here" (#146).
+        "rebaselined": (
+            "MCP tool schema re-baselined after a fingerprint change; "
+            "trust-on-first-use, not compared against the previous baseline"
+        ),
+    }
+    reason = _REASONS.get(status, "MCP tool schema observed")
     mcp_schema: dict[str, Any] = {
         "server_id": server_id(server) if server else "",
         "fingerprint": fingerprint,
         "tool_count": tool_count,
         "status": status,
+        # A baseline nobody has verified against a predecessor. Structured
+        # rather than left in the reason string so a SIEM can count them
+        # instead of matching prose.
+        **({"unverified_baseline": True} if status == "rebaselined" else {}),
         # Only a schema that MOVED is the technique. `new` is the first
         # sight of a server and `same` is a quiet reconnect; tagging either
         # as a rug pull would put a Defense Evasion label on installing a

--- a/apps/orchestrator/agentmetry/core/diagnostics/mcp_schema.py
+++ b/apps/orchestrator/agentmetry/core/diagnostics/mcp_schema.py
@@ -350,7 +350,19 @@ def classify_observation(
         # instead. Without this, the release that closed the `_meta` blind spot
         # would have reported a rug pull on every server every user had ever
         # observed, on upgrade day, and taught them the alert is noise.
-        return "new"
+        #
+        # `rebaselined` rather than `new`, and the distinction is the whole
+        # point (issue #146). `new` says "we had never seen this server". This
+        # says "we had a baseline, our hashing changed, and we are trusting
+        # whatever the server says today without comparing it to anything".
+        #
+        # Those carry different evidence. If a server was already poisoned
+        # before the upgrade, this observation adopts the poisoned state and an
+        # operator reading a quiet week must be able to see that, rather than
+        # find a word that also means "nothing has ever been wrong here".
+        # Trading a loud false positive for a silent false negative is the
+        # worse half of that trade for a recorder.
+        return "rebaselined"
     if existing.fingerprint == fp:
         return "same"
     if existing.tool_count == 0 and tool_count > 0:

--- a/apps/orchestrator/tests/test_mcp_meta_fingerprint.py
+++ b/apps/orchestrator/tests/test_mcp_meta_fingerprint.py
@@ -102,11 +102,82 @@ def test_a_baseline_from_the_old_hashing_re_baselines_instead_of_alerting(tmp_pa
     verdict = classify_observation(
         "postmark", fingerprint_tools(CLEAN), tool_count=1, path=store_file
     )
-    assert verdict == "new", (
+    assert verdict == "rebaselined", (
         "an old-hashing baseline must re-baseline, not report a change. Reporting "
         "`changed` here would alert on every server every user has observed, on "
         "the day they upgrade."
     )
+
+
+def test_a_rebaseline_is_not_reported_as_a_first_sighting(tmp_path):
+    """The correction to the first version of this fix (issue #146).
+
+    Returning `new` swapped a loud false positive for a silent false negative.
+    A server poisoned *before* the upgrade would have its poisoned state adopted
+    as the trusted baseline, under the same word used for a server nobody had
+    ever seen. An operator reading a quiet week could not tell "unchanged since
+    we started watching" from "we started watching again on Tuesday and cannot
+    speak for what came before".
+    """
+    store_file = tmp_path / "mcp-schema-fingerprints.json"
+    store_file.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "servers": {
+                    "known": {
+                        "fingerprint": "a" * 64,
+                        "tool_count": 3,
+                        "observed_at": "2026-08-01T00:00:00+00:00",
+                        "previous": "",
+                        "source": "mcp_proxy",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    seen_before = classify_observation(
+        "known", fingerprint_tools(CLEAN), tool_count=1, path=store_file
+    )
+    never_seen = classify_observation(
+        "brand-new-server", fingerprint_tools(CLEAN), tool_count=1, path=store_file
+    )
+
+    assert never_seen == "new"
+    assert seen_before != never_seen, (
+        "a re-baseline and a first sighting carry different evidence and must "
+        "not share a status"
+    )
+
+
+def test_the_rebaseline_event_says_it_was_not_compared():
+    """The distinction has to survive into the trail, not just the verdict.
+
+    A SIEM counts `unverified_baseline`; a human reads the reason. Both need to
+    say that nothing was compared, because that is the fact an auditor is
+    entitled to and the one a quiet status would hide.
+    """
+    from agentmetry.core.audit.ingest import build_schema_canonical
+
+    payload = {
+        "source_app": "mcp_proxy",
+        "event_type": "mcp_schema",
+        "schema_fingerprint": fingerprint_tools(CLEAN),
+        "schema_tool_count": len(CLEAN),
+        "tool": {"server": "postmark"},
+    }
+
+    rebaselined = build_schema_canonical(payload, "rebaselined")
+    first_sight = build_schema_canonical(payload, "new")
+
+    assert rebaselined["mcp_schema"]["unverified_baseline"] is True
+    assert "unverified_baseline" not in first_sight["mcp_schema"]
+    assert rebaselined["action"]["reason"] != first_sight["action"]["reason"]
+    assert "not compared" in rebaselined["action"]["reason"]
+    # A re-baseline is not a rug pull, so it must not carry the ATLAS technique.
+    assert "atlas" not in rebaselined["mcp_schema"]
 
 
 def test_a_real_change_after_re_baselining_is_still_caught(tmp_path):


### PR DESCRIPTION
Closes #146. **Corrects the migration I shipped in #144 yesterday.**

## What was wrong

#144 made a baseline computed under an older `FINGERPRINT_VERSION` re-baseline rather than report a change, so the release that closed the `_meta` blind spot would not alert on every server on upgrade day. That part was right.

It returned `new` to do it. And `new` already means "we had never seen this server".

So the two became indistinguishable, and they carry different evidence:

| Status | Means |
|---|---|
| `new` | We had never seen this server |
| `new` (before this PR) | We had a baseline, our hashing changed, and we are trusting whatever the server says today **without comparing it to anything** |

**If a server was already poisoned before the upgrade, the re-baseline adopts the poisoned state as trusted** and reports it under a word that also means nothing has ever been wrong here.

That trades a loud false positive for a silent false negative, which is the worse half of the trade for a recorder. It is also the same trust-on-first-use hole a reviewer had already raised about installation timing: a recorder installed after a swap has a permanently clean trail. #144 reintroduced it at the upgrade rather than the install, and for every server at once.

## The fix

```
new          outcome=success  unverified=False  MCP tool schema observed
rebaselined  outcome=success  unverified=True   ...re-baselined after a fingerprint change;
                                                 trust-on-first-use, not compared against
                                                 the previous baseline
changed      outcome=changed  unverified=False  ...rug-pull candidate
same         outcome=success  unverified=False  MCP tool schema observed
```

`unverified_baseline` is structured rather than left in prose, so a SIEM can count unverified baselines instead of matching a reason string. The status stays `success` and carries no ATLAS technique, because adopting a baseline is not a rug pull.

This is the same principle already used elsewhere here: coverage reports four states rather than a boolean so `unknown` cannot be read as `fine`, and a failed listing emits `unavailable` rather than nothing. The migration was the one place it was skipped.

## The test was pinning the bug

`test_a_baseline_from_the_old_hashing_re_baselines_instead_of_alerting` asserted the verdict was `new`. That was exactly the wrong thing to be satisfied by, and it passed while the defect existed. It now asserts the two statuses differ, and a second test pins that the distinction survives into the trail rather than living only in the verdict.

1,166 tests pass, ruff clean, ruleset fingerprint unchanged at `15846a0915769d4a`.

Reported by @Santoshkumarpuppala, who has now corrected two of these designs before they shipped and one after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)