### PR TITLE
fix: raw repo wellKnown provenance

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -22,7 +22,7 @@
       },
       "repositoryUrl": {
         "url": "https://github.com/blitzcrieg1/agentmetry",
-        "wellKnown": "https://github.com/blitzcrieg1/agentmetry/blob/master/.well-known/funding-manifest-urls"
+        "wellKnown": "https://raw.githubusercontent.com/blitzcrieg1/agentmetry/master/.well-known/funding-manifest-urls"
       },
       "licenses": [
         "spdx:Apache-2.0"


### PR DESCRIPTION
Switch projects[].repositoryUrl.wellKnown to raw.githubusercontent.com so FLOSS/fund can parse it as plain text.

Made with [Cursor](https://cursor.com)